### PR TITLE
Draft: Implement V5 transaction ID calculation directly in zebra-chain

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["asynchronous", "cryptography::cryptocurrencies", "encoding"]
 [features]
 
 #default = ["tx-v6"]
+default = ["txid-v5v6"]
 
 # Production features that activate extra functionality
 
@@ -56,6 +57,10 @@ tx-v6 = [
     "orchard_zsa",
     "nonempty"
 ]
+
+# Use direct Zebra implementation of txid computation for transaction versions 5 and 6
+# (i.e., don't use librustzcash for that, if enabled)
+txid-v5v6 = []
 
 [dependencies]
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -14,6 +14,9 @@ mod sighash;
 mod txid;
 mod unmined;
 
+#[cfg(feature = "txid-v5v6")]
+mod txid_v5v6;
+
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub mod builder;
 

--- a/zebra-chain/src/transaction/txid_v5v6.rs
+++ b/zebra-chain/src/transaction/txid_v5v6.rs
@@ -1,0 +1,22 @@
+use std::io;
+
+use crate::transaction::{self, Transaction};
+
+mod hasher;
+mod header_hasher;
+mod orchard_hasher;
+mod sapling_hasher;
+mod transaction_hasher;
+mod transparent_hasher;
+
+use transaction_hasher::hash_txid;
+
+pub fn calculate_txid(tx: &Transaction) -> Result<Option<transaction::Hash>, io::Error> {
+    match hash_txid(tx)? {
+        Some(hasher) => Ok(Some(transaction::Hash::from(
+            <[u8; 32]>::try_from(hasher.finalize().as_bytes())
+                .expect("Blake2bHash must be convertable to [u8; 32]"),
+        ))),
+        None => Ok(None),
+    }
+}

--- a/zebra-chain/src/transaction/txid_v5v6/hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/hasher.rs
@@ -1,0 +1,73 @@
+use std::io;
+
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use blake2b_simd::{Hash as Blake2bHash, Params, State};
+
+use crate::serialization::ZcashSerialize;
+
+pub(crate) struct Hasher(State);
+
+impl Hasher {
+    pub fn new(personal: &[u8; 16]) -> Self {
+        Self(Params::new().hash_length(32).personal(personal).to_state())
+    }
+
+    pub fn add<Digest: HashWriter>(mut self, digest: Digest) -> Result<Self, io::Error> {
+        digest.write(&mut self.0)?;
+        Ok(self)
+    }
+
+    pub fn add_all_if_any_nonempty(mut self, child_hashers: &[Self]) -> Result<Self, io::Error> {
+        if child_hashers.iter().any(|child| !child.is_empty()) {
+            for child in child_hashers {
+                child.write(&mut self.0)?
+            }
+        }
+        Ok(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.count() == 0
+    }
+
+    // FIXME: ref to self is used here instead of self only to make
+    // impl HashWriter for Hasher working - is this correct?
+    pub fn finalize(&self) -> Blake2bHash {
+        self.0.finalize()
+    }
+}
+
+pub(crate) trait HashWriter {
+    fn write<W: io::Write>(&self, writer: W) -> Result<(), io::Error>;
+}
+
+impl HashWriter for Hasher {
+    fn write<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_all(self.finalize().as_bytes())
+    }
+}
+
+impl HashWriter for u32 {
+    fn write<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_u32::<LittleEndian>(*self)
+    }
+}
+
+impl HashWriter for &[u8] {
+    fn write<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_all(self)
+    }
+}
+
+impl<const N: usize> HashWriter for [u8; N] {
+    fn write<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_all(self)
+    }
+}
+
+impl<T: ZcashSerialize> HashWriter for T {
+    fn write<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
+        self.zcash_serialize(writer)
+    }
+}

--- a/zebra-chain/src/transaction/txid_v5v6/header_hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/header_hasher.rs
@@ -1,0 +1,24 @@
+use std::io;
+
+use crate::{
+    parameters::TX_V5_VERSION_GROUP_ID,
+    transaction::{block, LockTime},
+};
+
+use super::hasher::Hasher;
+
+const ZCASH_HEADERS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdHeadersHash";
+
+pub(crate) fn hash_header(
+    version: u32,
+    consensus_branch_id: u32,
+    lock_time: LockTime,
+    expiry_height: block::Height,
+) -> Result<Hasher, io::Error> {
+    Hasher::new(ZCASH_HEADERS_HASH_PERSONALIZATION)
+        .add(version)?
+        .add(TX_V5_VERSION_GROUP_ID)?
+        .add(consensus_branch_id)?
+        .add(lock_time)?
+        .add(expiry_height.0)
+}

--- a/zebra-chain/src/transaction/txid_v5v6/orchard_hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/orchard_hasher.rs
@@ -1,0 +1,73 @@
+use std::io;
+
+use crate::orchard::{OrchardFlavour, ShieldedData};
+
+use super::hasher::Hasher;
+
+const ZCASH_ORCHARD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardHash";
+const ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActCHash";
+const ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActMHash";
+const ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActNHash";
+
+fn calculate_action_digests<V: OrchardFlavour>(
+    shielded_data: &ShieldedData<V>,
+) -> Result<Option<(Hasher, Hasher, Hasher)>, io::Error> {
+    if shielded_data.actions.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(shielded_data.actions().try_fold(
+            (
+                Hasher::new(ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION),
+                Hasher::new(ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION),
+                Hasher::new(ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION),
+            ),
+            |(compact_hasher, memos_hasher, noncompact_hasher),
+             action|
+             -> Result<(Hasher, Hasher, Hasher), io::Error> {
+                let enc_ciphertext = action.enc_ciphertext.as_ref();
+
+                let enc_ciphertext_compact = &enc_ciphertext[..V::ENCRYPTED_NOTE_COMPACT_SIZE];
+                let enc_ciphertext_memos = &enc_ciphertext
+                    [V::ENCRYPTED_NOTE_COMPACT_SIZE..V::ENCRYPTED_NOTE_COMPACT_SIZE + 512];
+                let enc_ciphertext_noncompact =
+                    &enc_ciphertext[V::ENCRYPTED_NOTE_COMPACT_SIZE + 512..];
+
+                Ok((
+                    compact_hasher
+                        .add(<[u8; 32]>::from(action.nullifier))?
+                        .add(<[u8; 32]>::from(action.cm_x))?
+                        .add(action.ephemeral_key)?
+                        .add(enc_ciphertext_compact)?,
+                    memos_hasher.add(enc_ciphertext_memos)?,
+                    noncompact_hasher
+                        .add(action.cv)?
+                        .add(<[u8; 32]>::from(action.rk))?
+                        .add(enc_ciphertext_noncompact)?
+                        .add(action.out_ciphertext.0)?,
+                ))
+            },
+        )?))
+    }
+}
+
+pub(crate) fn hash_orchard<V: OrchardFlavour>(
+    shielded_data: &Option<ShieldedData<V>>,
+) -> Result<Hasher, io::Error> {
+    let mut hasher = Hasher::new(ZCASH_ORCHARD_HASH_PERSONALIZATION);
+
+    if let Some(shielded_data) = shielded_data {
+        if let Some((actions_compact_digest, actions_memos_digest, actions_noncompact_digest)) =
+            calculate_action_digests(shielded_data)?
+        {
+            hasher = hasher
+                .add(actions_compact_digest)?
+                .add(actions_memos_digest)?
+                .add(actions_noncompact_digest)?
+                .add(shielded_data.flags)?
+                .add(shielded_data.value_balance())?
+                .add(shielded_data.shared_anchor)?;
+        }
+    }
+
+    Ok(hasher)
+}

--- a/zebra-chain/src/transaction/txid_v5v6/sapling_hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/sapling_hasher.rs
@@ -1,0 +1,99 @@
+use std::io;
+
+use crate::sapling::{SharedAnchor, ShieldedData};
+
+use super::hasher::Hasher;
+
+const ZCASH_SAPLING_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSaplingHash";
+
+const ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSSpendsHash";
+const ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSSpendCHash";
+const ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSSpendNHash";
+
+const ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSOutputHash";
+const ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSOutC__Hash";
+const ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSOutM__Hash";
+const ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSOutN__Hash";
+
+fn hash_sapling_spends(shielded_data: &ShieldedData<SharedAnchor>) -> Result<Hasher, io::Error> {
+    let anchor_bytes = shielded_data.shared_anchor().map(<[u8; 32]>::from);
+
+    let (spends_compact_digest, spends_noncompact_digest) = shielded_data.spends().try_fold(
+        (
+            Hasher::new(ZCASH_SAPLING_SPENDS_COMPACT_HASH_PERSONALIZATION),
+            Hasher::new(ZCASH_SAPLING_SPENDS_NONCOMPACT_HASH_PERSONALIZATION),
+        ),
+        |(compact_hasher, noncompact_hasher), spend| -> Result<(Hasher, Hasher), io::Error> {
+            Ok((
+                compact_hasher.add(<[u8; 32]>::from(spend.nullifier))?,
+                noncompact_hasher
+                    .add(spend.cv)?
+                    // shared_anchor must present if shielded_data has at least one spends,
+                    // so we can safely use unwrap here
+                    .add(anchor_bytes.unwrap())?
+                    .add(<[u8; 32]>::from(spend.rk.clone()))?,
+            ))
+        },
+    )?;
+
+    Hasher::new(ZCASH_SAPLING_SPENDS_HASH_PERSONALIZATION)
+        .add_all_if_any_nonempty(&[spends_compact_digest, spends_noncompact_digest])
+}
+
+fn hash_sapling_outputs(shielded_data: &ShieldedData<SharedAnchor>) -> Result<Hasher, io::Error> {
+    let (outputs_compact_digest, outputs_memos_digest, outputs_noncompact_digest) =
+        shielded_data.outputs().try_fold(
+            (
+                Hasher::new(ZCASH_SAPLING_OUTPUTS_COMPACT_HASH_PERSONALIZATION),
+                Hasher::new(ZCASH_SAPLING_OUTPUTS_MEMOS_HASH_PERSONALIZATION),
+                Hasher::new(ZCASH_SAPLING_OUTPUTS_NONCOMPACT_HASH_PERSONALIZATION),
+            ),
+            |(compact_hasher, memos_hasher, noncompoact_hasher),
+             output|
+             -> Result<(Hasher, Hasher, Hasher), io::Error> {
+                let enc_ciphertext = output.enc_ciphertext.0;
+
+                let enc_ciphertext_compact = &enc_ciphertext[..52];
+                let enc_ciphertext_memos = &enc_ciphertext[52..564];
+                let enc_ciphertext_noncompact = &enc_ciphertext[564..];
+
+                Ok((
+                    compact_hasher
+                        .add(output.cm_u.to_bytes())?
+                        .add(output.ephemeral_key)?
+                        .add(enc_ciphertext_compact)?,
+                    memos_hasher.add(enc_ciphertext_memos)?,
+                    noncompoact_hasher
+                        .add(output.cv)?
+                        .add(enc_ciphertext_noncompact)?
+                        .add(output.out_ciphertext.0)?,
+                ))
+            },
+        )?;
+
+    Hasher::new(ZCASH_SAPLING_OUTPUTS_HASH_PERSONALIZATION).add_all_if_any_nonempty(&[
+        outputs_compact_digest,
+        outputs_memos_digest,
+        outputs_noncompact_digest,
+    ])
+}
+
+pub(crate) fn hash_sapling(
+    shielded_data: &Option<ShieldedData<SharedAnchor>>,
+) -> Result<Hasher, io::Error> {
+    let mut hasher = Hasher::new(ZCASH_SAPLING_HASH_PERSONALIZATION);
+
+    if let Some(shielded_data) = shielded_data {
+        let sapling_spends_digest = hash_sapling_spends(shielded_data)?;
+        let sapling_outputs_digest = hash_sapling_outputs(shielded_data)?;
+
+        if !(sapling_spends_digest.is_empty() && sapling_outputs_digest.is_empty()) {
+            hasher = hasher
+                .add(sapling_spends_digest)?
+                .add(sapling_outputs_digest)?
+                .add(shielded_data.value_balance())?
+        }
+    }
+
+    Ok(hasher)
+}

--- a/zebra-chain/src/transaction/txid_v5v6/transaction_hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/transaction_hasher.rs
@@ -1,0 +1,63 @@
+use std::io;
+
+use crate::transaction::Transaction;
+
+use super::{
+    hasher::{HashWriter, Hasher},
+    header_hasher, orchard_hasher, sapling_hasher, transparent_hasher,
+};
+
+const ZCASH_TX_PERSONALIZATION_PREFIX: &[u8; 12] = b"ZcashTxHash_";
+
+fn calculate_tx_personal(consensus_branch_id: u32) -> Result<[u8; 16], io::Error> {
+    let mut tx_personal = [0; 16];
+    tx_personal[..12].copy_from_slice(ZCASH_TX_PERSONALIZATION_PREFIX);
+    consensus_branch_id.write(&mut tx_personal[12..])?;
+    Ok(tx_personal)
+}
+
+const TX_V5_ID: u32 = 5;
+const OVERWINTER_FLAG: u32 = 1 << 31;
+
+pub(crate) fn hash_txid(tx: &Transaction) -> Result<Option<Hasher>, io::Error> {
+    match tx {
+        Transaction::V5 {
+            network_upgrade,
+            lock_time,
+            expiry_height,
+            inputs,
+            outputs,
+            sapling_shielded_data,
+            orchard_shielded_data,
+        } => {
+            let consensus_branch_id = u32::from(
+                network_upgrade
+                    .branch_id()
+                    .expect("valid transactions must have a network upgrade with a branch id"),
+            );
+
+            let header_digest = header_hasher::hash_header(
+                TX_V5_ID | OVERWINTER_FLAG,
+                consensus_branch_id,
+                *lock_time,
+                *expiry_height,
+            )?;
+
+            let transparent_digest = transparent_hasher::hash_transparent(inputs, outputs)?;
+
+            let sapling_digest = sapling_hasher::hash_sapling(sapling_shielded_data)?;
+
+            let orchard_digest = orchard_hasher::hash_orchard(orchard_shielded_data)?;
+
+            Ok(Some(
+                Hasher::new(&calculate_tx_personal(consensus_branch_id)?)
+                    .add(header_digest)?
+                    .add(transparent_digest)?
+                    .add(sapling_digest)?
+                    .add(orchard_digest)?,
+            ))
+        }
+
+        _ => Ok(None),
+    }
+}

--- a/zebra-chain/src/transaction/txid_v5v6/transparent_hasher.rs
+++ b/zebra-chain/src/transaction/txid_v5v6/transparent_hasher.rs
@@ -1,0 +1,52 @@
+use std::io;
+
+use crate::{
+    transaction,
+    transparent::{Input, OutPoint, Output},
+};
+
+use super::hasher::Hasher;
+
+const ZCASH_TRANSPARENT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdTranspaHash";
+
+const ZCASH_PREVOUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdPrevoutHash";
+const ZCASH_SEQUENCE_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdSequencHash";
+const ZCASH_OUTPUTS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOutputsHash";
+
+const COINBASE_PREV_OUT: OutPoint = OutPoint {
+    hash: transaction::Hash([0; 32]),
+    index: 0xffff_ffff,
+};
+
+pub(crate) fn hash_transparent(inputs: &[Input], outputs: &[Output]) -> Result<Hasher, io::Error> {
+    let (prevouts_digest, sequence_digest) = inputs.iter().cloned().try_fold(
+        (
+            Hasher::new(ZCASH_PREVOUTS_HASH_PERSONALIZATION),
+            Hasher::new(ZCASH_SEQUENCE_HASH_PERSONALIZATION),
+        ),
+        |(prevouts_hasher, sequence_hasher), input| -> Result<(Hasher, Hasher), io::Error> {
+            let (prevout, sequence) = match input {
+                Input::PrevOut {
+                    outpoint, sequence, ..
+                } => (outpoint, sequence),
+                Input::Coinbase { sequence, .. } => (COINBASE_PREV_OUT, sequence),
+            };
+
+            Ok((
+                prevouts_hasher.add(prevout)?,
+                sequence_hasher.add(sequence)?,
+            ))
+        },
+    )?;
+
+    let outputs_digest = outputs
+        .iter()
+        .cloned()
+        .try_fold(Hasher::new(ZCASH_OUTPUTS_HASH_PERSONALIZATION), Hasher::add)?;
+
+    Hasher::new(ZCASH_TRANSPARENT_HASH_PERSONALIZATION).add_all_if_any_nonempty(&[
+        prevouts_digest,
+        sequence_digest,
+        outputs_digest,
+    ])
+}


### PR DESCRIPTION
## Description
This draft pull request proposes the implementation of transaction ID calculation for version 5 (V5) transactions directly within the `zebra-chain` crate. It also introduces a feature flag called `txid-v5v6` for toggling between the new internal implementation and the existing one that uses `librustzcash`.

V5 transaction ID calculation procedure has been implemented according to ZIP 244 spec (https://zips.z.cash/zip-0244). The existing unit test `zip244_txid` was used to check the correctness of the implementation - all checks of this test have been passed.

## Why this approach?
While the existing implementation relies on the `zcash_primitives` crate from `librustzcash` for V5 transaction ID calculation, implementing it directly in `zebra-chain` offers the following advantages:
- Reduces unnecessary dependencies on external crates from the old `librustzcash` repository.
- Avoids unnecessary serialization and deserialization overhead.
- Allows for more straightforward implementation of transaction ID calculation for the new V6 transaction format.

## Changes made
- Implemented V5 transaction ID calculation directly within the `zebra-chain` crate according to ZIP 244.
- Verified correctness using the existing unit test `zip244_txid`.

## Feature Flag
This implementation introduces a feature flag called `txid-v5v6` that controls whether the new internal implementation is used. If the flag is disabled, `zebra-chain` continues working with the `zcash_primitives` crate from `librustzcash` for transaction ID calculation.

## Future considerations
This implementation sets the foundation for extending support to V6 transaction ID calculation in the future. Future improvements may involve generalizing the algorithm to accommodate the additional components introduced in V6.
