### PR TITLE
Step 5: Modify Orchard proptest implementations to support ZSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
+ "proptest",
  "rand 0.8.5",
  "reddsa",
  "serde",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["zebra", "zcash"]
 categories = ["asynchronous", "cryptography::cryptocurrencies", "encoding"]
 
 [features]
-default = []
-#default = ["tx-v6"]
+#default = []
+default = ["tx-v6"]
 
 # Production features that activate extra functionality
 
@@ -178,6 +178,8 @@ rand_chacha = "0.3.1"
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 
 zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }
+
+orchard = { workspace = true, features = ["test-dependencies"] }
 
 [[bench]]
 name = "block"

--- a/zebra-chain/src/orchard/orchard_flavor_ext.rs
+++ b/zebra-chain/src/orchard/orchard_flavor_ext.rs
@@ -16,10 +16,21 @@ use super::note;
 #[cfg(feature = "tx-v6")]
 use crate::orchard_zsa::burn::BurnItem;
 
+#[cfg(not(any(test, feature = "proptest-impl")))]
+pub trait EncryptedNoteTest {}
+
+#[cfg(not(any(test, feature = "proptest-impl")))]
+impl<T> EncryptedNoteTest for T {}
+
+#[cfg(any(test, feature = "proptest-impl"))]
+pub trait EncryptedNoteTest: proptest::prelude::Arbitrary {}
+
+#[cfg(any(test, feature = "proptest-impl"))]
+impl<T: proptest::prelude::Arbitrary> EncryptedNoteTest for T {}
+
 /// A trait representing compile-time settings of Orchard Shielded Protocol used in
 /// the transactions `V5` and `V6`.
 pub trait OrchardFlavorExt: Clone + Debug {
-    /// A type representing an encrypted note for this protocol version.
     /// A type representing an encrypted note for this protocol version.
     type EncryptedNote: Clone
         + Debug
@@ -28,7 +39,8 @@ pub trait OrchardFlavorExt: Clone + Debug {
         + DeserializeOwned
         + Serialize
         + ZcashDeserialize
-        + ZcashSerialize;
+        + ZcashSerialize
+        + EncryptedNoteTest;
 
     /// FIXME: add doc
     type Flavor: orchard_flavor::OrchardFlavor;
@@ -37,6 +49,7 @@ pub trait OrchardFlavorExt: Clone + Debug {
     const ENCRYPTED_NOTE_SIZE: usize = Self::Flavor::ENC_CIPHERTEXT_SIZE;
 
     /// A type representing a burn field for this protocol version.
+    // FIXME: add cfg tx-v6 here?
     type BurnType: Clone + Debug + Default + ZcashDeserialize + ZcashSerialize;
 }
 

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -4,8 +4,9 @@
 #[cfg(any(test, feature = "proptest-impl"))]
 pub(crate) mod arbitrary;
 
+mod common;
+
 pub mod burn;
 pub mod issuance;
-pub mod serialize;
 
 pub use burn::BurnItem;

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -1,5 +1,9 @@
 //! Orchard ZSA related functionality.
 
+// FIXME: remove pub(crate) later if possible
+#[cfg(any(test, feature = "proptest-impl"))]
+pub(crate) mod arbitrary;
+
 pub mod burn;
 pub mod issuance;
 pub mod serialize;

--- a/zebra-chain/src/orchard_zsa/arbitrary.rs
+++ b/zebra-chain/src/orchard_zsa/arbitrary.rs
@@ -1,0 +1,64 @@
+//! Randomised data generation for Orchard ZSA types.
+
+use proptest::prelude::*;
+
+use orchard::{bundle::testing::BundleArb, issuance::testing::arb_signed_issue_bundle};
+
+// FIXME: consider using another value, i.e. define MAX_BURN_ITEMS constant for that
+use crate::{
+    orchard::{OrchardFlavorExt, OrchardVanilla, OrchardZSA},
+    transaction::arbitrary::MAX_ARBITRARY_ITEMS,
+};
+
+use super::{burn::BurnItem, issuance::IssueData};
+
+pub(crate) trait ArbitraryBurn: OrchardFlavorExt {
+    fn arbitrary_burn() -> BoxedStrategy<Self::BurnType>;
+    // FIXME: remove the following lines
+    //   where
+    //       Self: Sized
+}
+
+impl ArbitraryBurn for OrchardVanilla {
+    fn arbitrary_burn() -> BoxedStrategy<Self::BurnType> {
+        Just(Default::default()).boxed()
+    }
+}
+
+impl ArbitraryBurn for OrchardZSA {
+    fn arbitrary_burn() -> BoxedStrategy<Self::BurnType> {
+        prop::collection::vec(any::<BurnItem>(), 0..MAX_ARBITRARY_ITEMS).boxed()
+    }
+}
+
+impl Arbitrary for BurnItem {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // FIXME: move arb_asset_to_burn out of BundleArb in orchard
+        // as it does not depend on flavor (we pinned it here OrchardVanilla
+        // just for certainty, as there's no difference, which flavor to use)
+        // FIXME: consider to use BurnItem(asset_base, value.try_into().expect("Invalid value for Amount"))
+        // instead of filtering non-convertable values
+        // FIXME: should we filter/protect from including native assets into burn here?
+        BundleArb::<orchard::orchard_flavor::OrchardVanilla>::arb_asset_to_burn()
+            .prop_filter_map("Conversion to Amount failed", |(asset_base, value)| {
+                BurnItem::try_from((asset_base, value)).ok()
+            })
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for IssueData {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        arb_signed_issue_bundle(MAX_ARBITRARY_ITEMS)
+            .prop_map(|bundle| bundle.into())
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}

--- a/zebra-chain/src/orchard_zsa/burn.rs
+++ b/zebra-chain/src/orchard_zsa/burn.rs
@@ -8,7 +8,7 @@ use crate::{
     serialization::{SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize},
 };
 
-use orchard::note::AssetBase;
+use orchard::{note::AssetBase, value::NoteValue};
 
 use super::serialize::ASSET_BASE_SIZE;
 
@@ -20,6 +20,15 @@ const BURN_ITEM_SIZE: u64 = ASSET_BASE_SIZE + AMOUNT_SIZE;
 /// Represents an Orchard ZSA burn item.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BurnItem(AssetBase, Amount);
+
+// Convert from burn item type used in `orchard` crate
+impl TryFrom<(AssetBase, NoteValue)> for BurnItem {
+    type Error = crate::amount::Error;
+
+    fn try_from(item: (AssetBase, NoteValue)) -> Result<Self, Self::Error> {
+        Ok(Self(item.0, item.1.inner().try_into()?))
+    }
+}
 
 impl ZcashSerialize for BurnItem {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {

--- a/zebra-chain/src/orchard_zsa/common.rs
+++ b/zebra-chain/src/orchard_zsa/common.rs
@@ -7,7 +7,7 @@ use crate::serialization::{ReadZcashExt, SerializationError, ZcashDeserialize, Z
 use orchard::note::AssetBase;
 
 // The size of the serialized AssetBase in bytes (used for TrustedPreallocate impls)
-pub(crate) const ASSET_BASE_SIZE: u64 = 32;
+pub(super) const ASSET_BASE_SIZE: u64 = 32;
 
 impl ZcashSerialize for AssetBase {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {

--- a/zebra-chain/src/orchard_zsa/issuance.rs
+++ b/zebra-chain/src/orchard_zsa/issuance.rs
@@ -26,7 +26,7 @@ use orchard::{
     Address, Note,
 };
 
-use super::serialize::ASSET_BASE_SIZE;
+use super::common::ASSET_BASE_SIZE;
 
 /// Wrapper for `IssueBundle` used in the context of Transaction V6. This allows the implementation of
 /// a Serde serializer for unit tests within this crate.

--- a/zebra-chain/src/orchard_zsa/issuance.rs
+++ b/zebra-chain/src/orchard_zsa/issuance.rs
@@ -33,6 +33,12 @@ use super::serialize::ASSET_BASE_SIZE;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IssueData(IssueBundle<Signed>);
 
+impl From<IssueBundle<Signed>> for IssueData {
+    fn from(inner: IssueBundle<Signed>) -> Self {
+        Self(inner)
+    }
+}
+
 // Sizes of the serialized values for types in bytes (used for TrustedPreallocate impls)
 // FIXME: are those values correct (43, 32 etc.)?
 //const ISSUANCE_VALIDATING_KEY_SIZE: u64 = 32;

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -15,8 +15,8 @@ keywords = ["zebra", "zcash"]
 categories = ["asynchronous", "cryptography::cryptocurrencies"]
 
 [features]
-default = []
-#default = ["tx-v6"]
+#default = []
+default = ["tx-v6"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 


### PR DESCRIPTION
Updates the existing Orchard property-based test implementations to include transaction V6 ZSA fields (`burn` in `ShieldedData` and `orchard_zsa_issue_data`).

## Changes:

- Added the `TestArbitrary` trait to `orchard_flavor_ext` to conditionally modify the list of constraints for `EncryptedNote` and `BurnType` associated types.
- Implemented `Arbitrary` for `orchard::ShieldedData` as a generic type.
- Introduced a new type, `Burn`, which wraps `Vec<BurnItem>`. Implemented serialization/deserialization for it and placed it in `orchard_zsa/burn.rs`. Also moved `NoBurn` there from `orchard_flavor_ext.rs` for better code structuring.
- Renamed `serialize.rs` to `common.rs` in the `orchard_zsa` folder.
- Generalized the `v5_strategy` and `v6_strategy` functions in `transaction/arbitrary.rs` to work with V5 and V6 transactions, and to handle burn and issuance for V6.

**Note**: This is draft code that needs to be cleaned up, possibly refactored/improved, and the FIXMEs resolved.
