### PR TITLE
ZSA integration (step 6): Integrate Orchard ZSA Issuance note commitments with Shielded Data action commitments for V6 transactions

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -175,7 +175,7 @@ impl Block {
     }
 
     /// Access the [orchard note commitments](pallas::Base) from all transactions in this block.
-    pub fn orchard_note_commitments(&self) -> impl Iterator<Item = &pallas::Base> {
+    pub fn orchard_note_commitments(&self) -> impl Iterator<Item = pallas::Base> + '_ {
         self.transactions
             .iter()
             .flat_map(|transaction| transaction.orchard_note_commitments())

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -452,7 +452,7 @@ impl Block {
                                 sapling_tree.append(*sapling_note_commitment).unwrap();
                             }
                             for orchard_note_commitment in transaction.orchard_note_commitments() {
-                                orchard_tree.append(*orchard_note_commitment).unwrap();
+                                orchard_tree.append(orchard_note_commitment).unwrap();
                             }
                         }
                         new_transactions.push(Arc::new(transaction));

--- a/zebra-chain/src/orchard.rs
+++ b/zebra-chain/src/orchard.rs
@@ -30,6 +30,3 @@ pub(crate) use shielded_data::ActionCommon;
 
 #[cfg(feature = "tx-v6")]
 pub use orchard_flavor_ext::OrchardZSA;
-
-#[cfg(feature = "tx-v6")]
-pub(crate) use crate::orchard_zsa::issuance::IssueData;

--- a/zebra-chain/src/orchard/orchard_flavor_ext.rs
+++ b/zebra-chain/src/orchard/orchard_flavor_ext.rs
@@ -12,7 +12,7 @@ use orchard::{note_encryption::OrchardDomainCommon, orchard_flavor};
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 
 #[cfg(feature = "tx-v6")]
-use crate::orchard_zsa::burn::{Burn, NoBurn};
+use crate::orchard_zsa::{Burn, NoBurn};
 
 use super::note;
 

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -6,7 +6,8 @@ pub(crate) mod arbitrary;
 
 mod common;
 
-pub mod burn;
-pub mod issuance;
+mod burn;
+mod issuance;
 
-pub use burn::BurnItem;
+pub(crate) use burn::{Burn, NoBurn};
+pub(crate) use issuance::IssueData;

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -73,7 +73,7 @@ impl NoteCommitmentTrees {
 
         let sprout_note_commitments: Vec<_> = block.sprout_note_commitments().cloned().collect();
         let sapling_note_commitments: Vec<_> = block.sapling_note_commitments().cloned().collect();
-        let orchard_note_commitments: Vec<_> = block.orchard_note_commitments().cloned().collect();
+        let orchard_note_commitments: Vec<_> = block.orchard_note_commitments().collect();
 
         let mut sprout_result = None;
         let mut sapling_result = None;

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -53,67 +53,58 @@ use crate::{
     value_balance::{ValueBalance, ValueBalanceError},
 };
 
-/// Applies expression to different versions of `Transaction` to handle Orchard shielded data.
-macro_rules! match_orchard_shielded_data {
-    // Separate field sets and expressions for V5 and V6
-    ($self:expr, $pre_v5_expr:expr, { $( $v5_field:ident ),+ }, $v5_expr:expr, { $( $v6_field:ident ),+ }, $v6_expr:expr) => {
+// FIXME: doc this
+// Move down
+macro_rules! orchard_shielded_data_iter {
+    ($self:expr, $mapper:expr) => {
         match $self {
+            // No Orchard shielded data
             Transaction::V1 { .. }
             | Transaction::V2 { .. }
             | Transaction::V3 { .. }
-            | Transaction::V4 { .. } => $pre_v5_expr,
+            | Transaction::V4 { .. } => Box::new(std::iter::empty()),
 
-            Transaction::V5 { $( $v5_field ),+, .. } => $v5_expr,
+            Transaction::V5 {
+                orchard_shielded_data,
+                ..
+            } => Box::new(orchard_shielded_data.into_iter().flat_map($mapper)),
 
             #[cfg(feature = "tx-v6")]
-            Transaction::V6 { $( $v6_field ),+, .. } => $v6_expr,
+            Transaction::V6 {
+                orchard_shielded_data,
+                ..
+            } => Box::new(orchard_shielded_data.into_iter().flat_map($mapper)),
         }
     };
-
-    // Single field set and expression used for both V5 and V6
-    ($self:expr, $pre_v5_expr:expr, { $( $v5_v6_field:ident ),+ }, $v5_v6_expr:expr) => {
-        match_orchard_shielded_data!(
-            $self,
-            $pre_v5_expr,
-            { $( $v5_v6_field ),+ },
-            $v5_v6_expr,
-            { $( $v5_v6_field ),+ },
-            $v5_v6_expr
-        )
-    };
 }
 
-/// Creates an iterator over Orchard shielded data.
-///
-/// - `$self`: The `Transaction` instance.
-/// - `$mapper`: Function to apply to each data item.
-macro_rules! orchard_shielded_data_iter {
-    ($self:expr, $mapper:expr) => {
-        match_orchard_shielded_data!(
-            $self,
-            Box::new(std::iter::empty()),
-            { orchard_shielded_data },
-            Box::new(orchard_shielded_data.into_iter().flat_map($mapper))
-        )
-    };
-}
-
-/// Retrieves a specific field from Orchard shielded data.
-///
-/// - `$self`: The `Transaction` instance.
-/// - `$field`: The field to access
+// FIXME: doc this
+// Move down
 macro_rules! orchard_shielded_data_field {
     ($self:expr, $field:ident) => {
-        match_orchard_shielded_data!(
-            $self,
-            None,
-            { orchard_shielded_data },
-            orchard_shielded_data.as_ref().map(|d| d.$field)
-        )
+        match $self {
+            // No Orchard shielded data
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. } => None,
+
+            Transaction::V5 {
+                orchard_shielded_data,
+                ..
+            } => orchard_shielded_data.as_ref().map(|data| data.$field),
+
+            #[cfg(feature = "tx-v6")]
+            Transaction::V6 {
+                orchard_shielded_data,
+                ..
+            } => orchard_shielded_data.as_ref().map(|data| data.$field),
+        }
     };
 }
 
-/// Generates match patterns for `Transaction::V5` and `Transaction::V6`
+// FIXME:
+// Define the macro for including the V6 pattern
 #[cfg(feature = "tx-v6")]
 macro_rules! tx_v5_and_v6 {
     { $($fields:tt)* } => {
@@ -121,7 +112,6 @@ macro_rules! tx_v5_and_v6 {
     };
 }
 
-/// Generates a match pattern for `Transaction::V5` only
 #[cfg(not(feature = "tx-v6"))]
 macro_rules! tx_v5_and_v6 {
     { $($fields:tt)* } => {
@@ -1475,14 +1465,33 @@ impl Transaction {
     /// See `orchard_value_balance` for details.
     #[cfg(any(test, feature = "proptest-impl"))]
     pub fn orchard_value_balance_mut(&mut self) -> Option<&mut Amount<NegativeAllowed>> {
-        match_orchard_shielded_data!(
-            self,
-            None,
-            { orchard_shielded_data },
-            orchard_shielded_data
-                .as_mut()
-                .map(|shielded_data| &mut shielded_data.value_balance)
-        )
+        match self {
+            Transaction::V5 {
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ..
+            } => Some(&mut orchard_shielded_data.value_balance),
+
+            #[cfg(feature = "tx-v6")]
+            Transaction::V6 {
+                orchard_shielded_data: Some(orchard_shielded_data),
+                ..
+            } => Some(&mut orchard_shielded_data.value_balance),
+
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. }
+            | Transaction::V5 {
+                orchard_shielded_data: None,
+                ..
+            } => None,
+
+            #[cfg(feature = "tx-v6")]
+            Transaction::V6 {
+                orchard_shielded_data: None,
+                ..
+            } => None,
+        }
     }
 
     /// Returns the value balances for this transaction using the provided transparent outputs.

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -1046,8 +1046,32 @@ impl Transaction {
 
     /// Access the note commitments in this transaction, if there are any,
     /// regardless of version.
-    pub fn orchard_note_commitments(&self) -> Box<dyn Iterator<Item = &pallas::Base> + '_> {
-        orchard_shielded_data_iter!(self, orchard::ShieldedData::note_commitments)
+    pub fn orchard_note_commitments(&self) -> Box<dyn Iterator<Item = pallas::Base> + '_> {
+        match_orchard_shielded_data!(
+            self,
+            Box::new(std::iter::empty()),
+            { orchard_shielded_data },
+            Box::new(
+                orchard_shielded_data
+                    .iter()
+                    .flat_map(orchard::ShieldedData::note_commitments)
+                    .cloned()
+            ),
+            { orchard_shielded_data, orchard_zsa_issue_data },
+            {
+                Box::new(
+                    orchard_shielded_data
+                        .iter()
+                        .flat_map(orchard::ShieldedData::note_commitments)
+                        .cloned()
+                        .chain(
+                            orchard_zsa_issue_data
+                              .iter()
+                              .flat_map(orchard_zsa::IssueData::note_commitments)
+                        )
+                )
+            }
+        )
     }
 
     /// Access the [`orchard::Flags`] in this transaction, if there is any,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -40,7 +40,7 @@ pub use unmined::{
 
 use crate::{
     amount::{Amount, Error as AmountError, NegativeAllowed, NonNegative},
-    block, orchard,
+    block, orchard, orchard_zsa,
     parameters::{ConsensusBranchId, NetworkUpgrade},
     primitives::{ed25519, Bctv14Proof, Groth16Proof},
     sapling,
@@ -245,7 +245,7 @@ pub enum Transaction {
         orchard_shielded_data: Option<orchard::ShieldedData<orchard::OrchardZSA>>,
         /// The ZSA issuance data for this transaction, if any.
         #[cfg(feature = "tx-v6")]
-        orchard_zsa_issue_data: Option<orchard::IssueData>,
+        orchard_zsa_issue_data: Option<orchard_zsa::IssueData>,
     },
 }
 

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 #[cfg(feature = "tx-v6")]
-use crate::orchard_zsa::issuance::IssueData;
+use crate::orchard_zsa::IssueData;
 
 use itertools::Itertools;
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -800,7 +800,6 @@ fn calculate_orchard_subtree(
         let orchard_note_commitments = block
             .orchard_note_commitments()
             .take(prev_remaining_notes)
-            .cloned()
             .collect();
 
         // This takes less than 1 second per tree, so we don't need to make it cancellable.


### PR DESCRIPTION
This pull request enhances the `zebra-chain` crate to handle issuance action note commitments for V6 transactions.

The main change merges note commitments from Orchard ZSA issuance actions with regular shielded data action note commitments in `Transaction::orchard_note_commitments` method when an issuance is present in a V6 transaction.

This integration allows for the automatic handling of issuance note commitments alongside shielded data commitments in other parts of the Zebra codebase, particularly within the note commitment Merkle tree in the `zebra_state` crate.

V5 transactions remain unaffected, ensuring their existing behavior is preserved.