### PR TITLE
Tracks issued assets state and contextually validates issue actions and asset burns

### DIFF
--- a/zebra-chain/src/orchard/orchard_flavor_ext.rs
+++ b/zebra-chain/src/orchard/orchard_flavor_ext.rs
@@ -9,7 +9,10 @@ use proptest_derive::Arbitrary;
 
 use orchard::{note_encryption::OrchardDomainCommon, orchard_flavor};
 
-use crate::serialization::{ZcashDeserialize, ZcashSerialize};
+use crate::{
+    orchard_zsa,
+    serialization::{ZcashDeserialize, ZcashSerialize},
+};
 
 #[cfg(feature = "tx-v6")]
 use crate::orchard_zsa::{Burn, NoBurn};
@@ -50,7 +53,13 @@ pub trait OrchardFlavorExt: Clone + Debug {
 
     /// A type representing a burn field for this protocol version.
     #[cfg(feature = "tx-v6")]
-    type BurnType: Clone + Debug + Default + ZcashDeserialize + ZcashSerialize + TestArbitrary;
+    type BurnType: Clone
+        + Debug
+        + Default
+        + ZcashDeserialize
+        + ZcashSerialize
+        + TestArbitrary
+        + AsRef<[orchard_zsa::BurnItem]>;
 }
 
 /// A structure representing a tag for Orchard protocol variant used for the transaction version `V5`.

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -13,4 +13,4 @@ mod issuance;
 pub(crate) use burn::{Burn, BurnItem, NoBurn};
 pub(crate) use issuance::IssueData;
 
-pub use asset_state::{AssetBase, AssetState, AssetStateChange, IssuedAssetsChange};
+pub use asset_state::{AssetBase, AssetState, AssetStateChange, IssuedAssets, IssuedAssetsChange};

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -6,8 +6,11 @@ pub(crate) mod arbitrary;
 
 mod common;
 
+mod asset_state;
 mod burn;
 mod issuance;
 
-pub(crate) use burn::{Burn, NoBurn};
+pub(crate) use burn::{Burn, BurnItem, NoBurn};
 pub(crate) use issuance::IssueData;
+
+pub use asset_state::{AssetBase, AssetState, AssetStateChange, IssuedAssetsChange};

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -20,7 +20,10 @@ pub struct AssetState {
 }
 
 /// A change to apply to the issued assets map.
-// TODO: Reference ZIP
+// TODO:
+// - Reference ZIP
+// - Make this an enum of _either_ a finalization _or_ a supply change
+//    (applying the finalize flag for each issuance note will cause unexpected panics).
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetStateChange {
     /// Whether the asset should be finalized such that no more of it can be issued.

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -10,7 +10,7 @@ use crate::block::Block;
 use super::BurnItem;
 
 /// The circulating supply and whether that supply has been finalized.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetState {
     /// Indicates whether the asset is finalized such that no more of it can be issued.
     pub is_finalized: bool,
@@ -27,6 +27,17 @@ pub struct AssetStateChange {
     pub is_finalized: bool,
     /// The change in supply from newly issued assets or burned assets.
     pub supply_change: i128,
+}
+
+impl AssetState {
+    fn with_change(mut self, change: AssetStateChange) -> Self {
+        self.is_finalized |= change.is_finalized;
+        self.total_supply = self
+            .total_supply
+            .checked_add_signed(change.supply_change)
+            .expect("burn amounts must not be greater than initial supply");
+        self
+    }
 }
 
 impl AssetStateChange {
@@ -77,6 +88,33 @@ impl std::ops::AddAssign for AssetStateChange {
     }
 }
 
+/// An `issued_asset` map
+// TODO: Reference ZIP
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct IssuedAssets(HashMap<AssetBase, AssetState>);
+
+impl IssuedAssets {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    fn update<'a>(&mut self, issued_assets: impl Iterator<Item = (AssetBase, AssetState)> + 'a) {
+        for (asset_base, asset_state) in issued_assets {
+            self.0.insert(asset_base, asset_state);
+        }
+    }
+}
+
+impl IntoIterator for IssuedAssets {
+    type Item = (AssetBase, AssetState);
+
+    type IntoIter = std::collections::hash_map::IntoIter<AssetBase, AssetState>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// A map of changes to apply to the issued assets map.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IssuedAssetsChange(HashMap<AssetBase, AssetStateChange>);
@@ -108,5 +146,36 @@ impl IssuedAssetsChange {
         }
 
         (burn_change, issuance_change)
+    }
+
+    /// Consumes self and accepts a closure for looking up previous asset states.
+    ///
+    /// Applies changes in self to the previous asset state.
+    ///
+    /// Returns an [`IssuedAssets`] with the updated asset states.
+    pub fn apply_with(self, f: impl Fn(AssetBase) -> AssetState) -> IssuedAssets {
+        let mut issued_assets = IssuedAssets::new();
+
+        issued_assets.update(
+            self.0
+                .into_iter()
+                .map(|(asset_base, change)| (asset_base, f(asset_base).with_change(change))),
+        );
+
+        issued_assets
+    }
+}
+
+impl std::ops::Add for IssuedAssetsChange {
+    type Output = Self;
+
+    fn add(mut self, mut rhs: Self) -> Self {
+        if self.0.len() > rhs.0.len() {
+            self.update(rhs.0.into_iter());
+            self
+        } else {
+            rhs.update(self.0.into_iter());
+            rhs
+        }
     }
 }

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -1,0 +1,112 @@
+//! Defines and implements the issued asset state types
+
+use std::{collections::HashMap, sync::Arc};
+
+use orchard::issuance::IssueAction;
+pub use orchard::note::AssetBase;
+
+use crate::block::Block;
+
+use super::BurnItem;
+
+/// The circulating supply and whether that supply has been finalized.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AssetState {
+    /// Indicates whether the asset is finalized such that no more of it can be issued.
+    pub is_finalized: bool,
+
+    /// The circulating supply that has been issued for an asset.
+    pub total_supply: u128,
+}
+
+/// A change to apply to the issued assets map.
+// TODO: Reference ZIP
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AssetStateChange {
+    /// Whether the asset should be finalized such that no more of it can be issued.
+    pub is_finalized: bool,
+    /// The change in supply from newly issued assets or burned assets.
+    pub supply_change: i128,
+}
+
+impl AssetStateChange {
+    fn from_note(is_finalized: bool, note: orchard::Note) -> (AssetBase, Self) {
+        (
+            note.asset(),
+            Self {
+                is_finalized,
+                supply_change: note.value().inner().into(),
+            },
+        )
+    }
+
+    fn from_notes(
+        is_finalized: bool,
+        notes: &[orchard::Note],
+    ) -> impl Iterator<Item = (AssetBase, Self)> + '_ {
+        notes
+            .iter()
+            .map(move |note| Self::from_note(is_finalized, *note))
+    }
+
+    fn from_issue_actions<'a>(
+        actions: impl Iterator<Item = &'a IssueAction> + 'a,
+    ) -> impl Iterator<Item = (AssetBase, Self)> + 'a {
+        actions.flat_map(|action| Self::from_notes(action.is_finalized(), action.notes()))
+    }
+
+    fn from_burn(burn: &BurnItem) -> (AssetBase, Self) {
+        (
+            burn.asset(),
+            Self {
+                is_finalized: false,
+                supply_change: -i128::from(burn.amount()),
+            },
+        )
+    }
+
+    fn from_burns(burns: &[BurnItem]) -> impl Iterator<Item = (AssetBase, Self)> + '_ {
+        burns.iter().map(Self::from_burn)
+    }
+}
+
+impl std::ops::AddAssign for AssetStateChange {
+    fn add_assign(&mut self, rhs: Self) {
+        self.is_finalized |= rhs.is_finalized;
+        self.supply_change += rhs.supply_change;
+    }
+}
+
+/// A map of changes to apply to the issued assets map.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IssuedAssetsChange(HashMap<AssetBase, AssetStateChange>);
+
+impl IssuedAssetsChange {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    fn update<'a>(&mut self, changes: impl Iterator<Item = (AssetBase, AssetStateChange)> + 'a) {
+        for (asset_base, change) in changes {
+            *self.0.entry(asset_base).or_default() += change;
+        }
+    }
+
+    /// Accepts a reference to an [`Arc<Block>`].
+    ///
+    /// Returns a tuple, ([`IssuedAssetsChange`], [`IssuedAssetsChange`]), where
+    /// the first item is from burns and the second one is for issuance.
+    pub fn from_block(block: &Arc<Block>) -> (Self, Self) {
+        let mut burn_change = Self::new();
+        let mut issuance_change = Self::new();
+
+        for transaction in &block.transactions {
+            burn_change.update(AssetStateChange::from_burns(transaction.orchard_burns()));
+            issuance_change.update(AssetStateChange::from_issue_actions(
+                transaction.orchard_issue_actions(),
+            ));
+        }
+
+        (burn_change, issuance_change)
+    }
+}

--- a/zebra-chain/src/orchard_zsa/issuance.rs
+++ b/zebra-chain/src/orchard_zsa/issuance.rs
@@ -57,6 +57,11 @@ impl IssueData {
             })
         })
     }
+
+    /// Returns issuance actions
+    pub fn actions(&self) -> &NonEmpty<IssueAction> {
+        self.0.actions()
+    }
 }
 
 // Sizes of the serialized values for types in bytes (used for TrustedPreallocate impls)

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -24,6 +24,7 @@ use tracing::Instrument;
 use zebra_chain::{
     amount::Amount,
     block,
+    orchard_zsa::IssuedAssetsChange,
     parameters::{subsidy::FundingStreamReceiver, Network},
     transparent,
     work::equihash,
@@ -314,6 +315,8 @@ where
             let new_outputs = Arc::into_inner(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
+            let (issued_assets_burns_change, issued_assets_issuance_change) =
+                IssuedAssetsChange::from_block(&block);
             let prepared_block = zs::SemanticallyVerifiedBlock {
                 block,
                 hash,
@@ -321,6 +324,8 @@ where
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: Some(expected_deferred_amount),
+                issued_assets_burns_change,
+                issued_assets_issuance_change,
             };
 
             // Return early for proposal requests when getblocktemplate-rpcs feature is enabled

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -315,7 +315,7 @@ where
             let new_outputs = Arc::into_inner(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
-            let (burns, issuance) = IssuedAssetsChange::from_block(&block);
+            let (burns, issuance) = IssuedAssetsChange::from_transactions(&block.transactions);
             let prepared_block = zs::SemanticallyVerifiedBlock {
                 block,
                 hash,

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -29,7 +29,7 @@ use zebra_chain::{
     transparent,
     work::equihash,
 };
-use zebra_state as zs;
+use zebra_state::{self as zs, IssuedAssetsOrChanges};
 
 use crate::{error::*, transaction as tx, BoxError};
 
@@ -315,8 +315,7 @@ where
             let new_outputs = Arc::into_inner(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
-            let (issued_assets_burns_change, issued_assets_issuance_change) =
-                IssuedAssetsChange::from_block(&block);
+            let (burns, issuance) = IssuedAssetsChange::from_block(&block);
             let prepared_block = zs::SemanticallyVerifiedBlock {
                 block,
                 hash,
@@ -324,8 +323,10 @@ where
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: Some(expected_deferred_amount),
-                issued_assets_burns_change,
-                issued_assets_issuance_change,
+                issued_assets_changes: IssuedAssetsOrChanges::BurnAndIssuanceChanges {
+                    burns,
+                    issuance,
+                },
             };
 
             // Return early for proposal requests when getblocktemplate-rpcs feature is enabled

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -42,7 +42,7 @@ use crate::{
         Progress::{self, *},
         TargetHeight::{self, *},
     },
-    error::{BlockError, SubsidyError},
+    error::{BlockError, SubsidyError, TransactionError},
     funding_stream_values, BoxError, ParameterCheckpoint as _,
 };
 
@@ -619,7 +619,8 @@ where
         };
 
         // don't do precalculation until the block passes basic difficulty checks
-        let block = CheckpointVerifiedBlock::new(block, Some(hash), expected_deferred_amount);
+        let block = CheckpointVerifiedBlock::new(block, Some(hash), expected_deferred_amount)
+            .ok_or_else(|| VerifyBlockError::from(TransactionError::InvalidAssetIssuanceOrBurn))?;
 
         crate::block::check::merkle_root_validity(
             &self.network,

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -239,6 +239,9 @@ pub enum TransactionError {
     #[error("failed to verify ZIP-317 transaction rules, transaction was not inserted to mempool")]
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Zip317(#[from] zebra_chain::transaction::zip317::Error),
+
+    #[error("failed to validate asset issuance and/or burns")]
+    InvalidAssetIssuanceOrBurn,
 }
 
 impl From<ValidateContextError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -19,6 +19,7 @@ use tracing::Instrument;
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block, orchard,
+    orchard_zsa::IssuedAssetsChange,
     parameters::{Network, NetworkUpgrade},
     primitives::Groth16Proof,
     sapling,
@@ -143,6 +144,10 @@ pub enum Response {
         /// The number of legacy signature operations in this transaction's
         /// transparent inputs and outputs.
         legacy_sigop_count: u64,
+
+        /// The changes to the issued assets map that should be applied for
+        /// this transaction.
+        issued_assets_change: IssuedAssetsChange,
     },
 
     /// A response to a mempool transaction verification request.
@@ -473,6 +478,7 @@ where
                     tx_id,
                     miner_fee,
                     legacy_sigop_count,
+                    issued_assets_change: IssuedAssetsChange::from_transaction(&tx).ok_or(TransactionError::InvalidAssetIssuanceOrBurn)?,
                 },
                 Request::Mempool { transaction, .. } => {
                     let transaction = VerifiedUnminedTx::new(

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -13,8 +13,8 @@ use zebra_chain::{
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_state::{
-    spawn_init_read_only, ChainTipBlock, ChainTipChange, ChainTipSender, CheckpointVerifiedBlock,
-    LatestChainTip, NonFinalizedState, ReadStateService, SemanticallyVerifiedBlock, ZebraDb,
+    spawn_init_read_only, ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip,
+    NonFinalizedState, ReadStateService, SemanticallyVerifiedBlock, ZebraDb,
     MAX_BLOCK_REORG_HEIGHT,
 };
 
@@ -262,7 +262,7 @@ impl TrustedChainSync {
         tokio::task::spawn_blocking(move || {
             let (height, hash) = db.tip()?;
             db.block(height.into())
-                .map(|block| CheckpointVerifiedBlock::with_hash(block, hash))
+                .map(|block| SemanticallyVerifiedBlock::with_hash(block, hash))
                 .map(ChainTipBlock::from)
         })
         .wait_for_panics()

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -12,7 +12,8 @@ use zebra_chain::{
 };
 
 use crate::{
-    request::ContextuallyVerifiedBlock, service::chain_tip::ChainTipBlock,
+    request::{ContextuallyVerifiedBlock, IssuedAssetsOrChanges},
+    service::chain_tip::ChainTipBlock,
     SemanticallyVerifiedBlock,
 };
 
@@ -31,8 +32,7 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
-        let (issued_assets_burns_change, issued_assets_issuance_change) =
-            IssuedAssetsChange::from_block(&block);
+        let (burns, issuance) = IssuedAssetsChange::from_block(&block);
 
         SemanticallyVerifiedBlock {
             block,
@@ -41,8 +41,10 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
-            issued_assets_burns_change,
-            issued_assets_issuance_change,
+            issued_assets_changes: IssuedAssetsOrChanges::BurnAndIssuanceChanges {
+                burns,
+                issuance,
+            },
         }
     }
 }
@@ -117,8 +119,7 @@ impl ContextuallyVerifiedBlock {
             new_outputs,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_burns_change: _,
-            issued_assets_issuance_change: _,
+            issued_assets_changes: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -5,15 +5,13 @@ use std::sync::Arc;
 use zebra_chain::{
     amount::Amount,
     block::{self, Block},
-    orchard_zsa::IssuedAssetsChange,
     transaction::Transaction,
     transparent,
     value_balance::ValueBalance,
 };
 
 use crate::{
-    request::{ContextuallyVerifiedBlock, IssuedAssetsOrChanges},
-    service::chain_tip::ChainTipBlock,
+    request::ContextuallyVerifiedBlock, service::chain_tip::ChainTipBlock,
     SemanticallyVerifiedBlock,
 };
 
@@ -32,7 +30,6 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
-        let (burns, issuance) = IssuedAssetsChange::from_transactions(&block.transactions);
 
         SemanticallyVerifiedBlock {
             block,
@@ -41,10 +38,7 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
-            issued_assets_changes: IssuedAssetsOrChanges::BurnAndIssuanceChanges {
-                burns,
-                issuance,
-            },
+            issued_assets_change: None,
         }
     }
 }
@@ -123,7 +117,7 @@ impl ContextuallyVerifiedBlock {
             new_outputs,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_changes: _,
+            issued_assets_change: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use zebra_chain::{
     amount::Amount,
     block::{self, Block},
+    orchard_zsa::IssuedAssetsChange,
     transaction::Transaction,
     transparent,
     value_balance::ValueBalance,
@@ -30,6 +31,7 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
+        let issued_assets_change = IssuedAssetsChange::from_transactions(&block.transactions);
 
         SemanticallyVerifiedBlock {
             block,
@@ -38,7 +40,7 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
-            issued_assets_change: None,
+            issued_assets_change,
         }
     }
 }

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -103,8 +103,12 @@ impl ContextuallyVerifiedBlock {
             .map(|outpoint| (outpoint, zero_utxo.clone()))
             .collect();
 
-        ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, zero_spent_utxos)
-            .expect("all UTXOs are provided with zero values")
+        ContextuallyVerifiedBlock::with_block_and_spent_utxos(
+            block,
+            zero_spent_utxos,
+            Default::default(),
+        )
+        .expect("all UTXOs are provided with zero values")
     }
 
     /// Create a [`ContextuallyVerifiedBlock`] from a [`Block`] or [`SemanticallyVerifiedBlock`],
@@ -133,6 +137,7 @@ impl ContextuallyVerifiedBlock {
             spent_outputs: new_outputs,
             transaction_hashes,
             chain_value_pool_change: ValueBalance::zero(),
+            issued_assets: Default::default(),
         }
     }
 }

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use zebra_chain::{
     amount::Amount,
     block::{self, Block},
+    orchard_zsa::IssuedAssetsChange,
     transaction::Transaction,
     transparent,
     value_balance::ValueBalance,
@@ -30,6 +31,8 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
+        let (issued_assets_burns_change, issued_assets_issuance_change) =
+            IssuedAssetsChange::from_block(&block);
 
         SemanticallyVerifiedBlock {
             block,
@@ -38,6 +41,8 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
+            issued_assets_burns_change,
+            issued_assets_issuance_change,
         }
     }
 }
@@ -112,6 +117,8 @@ impl ContextuallyVerifiedBlock {
             new_outputs,
             transaction_hashes,
             deferred_balance: _,
+            issued_assets_burns_change: _,
+            issued_assets_issuance_change: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -32,7 +32,7 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
-        let (burns, issuance) = IssuedAssetsChange::from_block(&block);
+        let (burns, issuance) = IssuedAssetsChange::from_transactions(&block.transactions);
 
         SemanticallyVerifiedBlock {
             block,

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -31,7 +31,8 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
-        let issued_assets_change = IssuedAssetsChange::from_transactions(&block.transactions);
+        let issued_assets_changes = IssuedAssetsChange::from_transactions(&block.transactions)
+            .expect("prepared blocks should be semantically valid");
 
         SemanticallyVerifiedBlock {
             block,
@@ -40,7 +41,7 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
-            issued_assets_change,
+            issued_assets_changes,
         }
     }
 }
@@ -119,7 +120,7 @@ impl ContextuallyVerifiedBlock {
             new_outputs,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_change: _,
+            issued_assets_changes: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -264,6 +264,12 @@ pub enum ValidateContextError {
         tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
+
+    #[error("burn amounts must be less than issued asset supply")]
+    InvalidBurn,
+
+    #[error("must not issue finalized assets")]
+    InvalidIssuance,
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -42,7 +42,7 @@ pub use error::{
     ValidateContextError,
 };
 pub use request::{
-    CheckpointVerifiedBlock, HashOrHeight, IssuedAssetsOrChanges, ReadRequest, Request,
+    CheckpointVerifiedBlock, HashOrHeight, IssuedAssetsOrChange, ReadRequest, Request,
     SemanticallyVerifiedBlock,
 };
 pub use response::{KnownBlock, MinedTx, ReadResponse, Response};

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -42,7 +42,8 @@ pub use error::{
     ValidateContextError,
 };
 pub use request::{
-    CheckpointVerifiedBlock, HashOrHeight, ReadRequest, Request, SemanticallyVerifiedBlock,
+    CheckpointVerifiedBlock, HashOrHeight, IssuedAssetsOrChanges, ReadRequest, Request,
+    SemanticallyVerifiedBlock,
 };
 pub use response::{KnownBlock, MinedTx, ReadResponse, Response};
 pub use service::{

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -365,7 +365,7 @@ impl FinalizedBlock {
             transaction_hashes: block.transaction_hashes,
             treestate,
             deferred_balance: block.deferred_balance,
-            issued_assets: block.issued_assets_changes.combine(),
+            issued_assets: block.issued_assets_changes,
         }
     }
 }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -528,7 +528,11 @@ impl SemanticallyVerifiedBlock {
 
 impl From<Arc<Block>> for CheckpointVerifiedBlock {
     fn from(block: Arc<Block>) -> Self {
-        CheckpointVerifiedBlock(SemanticallyVerifiedBlock::from(block))
+        let mut block = SemanticallyVerifiedBlock::from(block);
+        block.issued_assets_change =
+            IssuedAssetsChange::from_transactions(&block.block.transactions);
+
+        CheckpointVerifiedBlock(block)
     }
 }
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -227,6 +227,10 @@ pub struct ContextuallyVerifiedBlock {
 
     /// The sum of the chain value pool changes of all transactions in this block.
     pub(crate) chain_value_pool_change: ValueBalance<NegativeAllowed>,
+
+    /// A partial map of `issued_assets` with entries for asset states that were updated in
+    /// this block.
+    pub(crate) issued_assets: IssuedAssets,
 }
 
 /// Wraps note commitment trees and the history tree together.
@@ -431,6 +435,7 @@ impl ContextuallyVerifiedBlock {
     pub fn with_block_and_spent_utxos(
         semantically_verified: SemanticallyVerifiedBlock,
         mut spent_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+        issued_assets: IssuedAssets,
     ) -> Result<Self, ValueBalanceError> {
         let SemanticallyVerifiedBlock {
             block,
@@ -459,6 +464,7 @@ impl ContextuallyVerifiedBlock {
                 &utxos_from_ordered_utxos(spent_outputs),
                 deferred_balance,
             )?,
+            issued_assets,
         })
     }
 }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -116,8 +116,7 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             new_outputs: _,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_burns_change: _,
-            issued_assets_issuance_change: _,
+            issued_assets_changes: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -116,7 +116,7 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             new_outputs: _,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_change: _,
+            issued_assets_changes: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -116,7 +116,7 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             new_outputs: _,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_changes: _,
+            issued_assets_change: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -116,6 +116,8 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             new_outputs: _,
             transaction_hashes,
             deferred_balance: _,
+            issued_assets_burns_change: _,
+            issued_assets_issuance_change: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -28,6 +28,7 @@ use crate::service::non_finalized_state::Chain;
 
 pub(crate) mod anchors;
 pub(crate) mod difficulty;
+pub(crate) mod issuance;
 pub(crate) mod nullifier;
 pub(crate) mod utxo;
 

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -27,7 +27,7 @@ pub fn valid_burns_and_issuance(
             .issued_asset(&asset_base)
             .or_else(|| finalized_state.issued_asset(&asset_base))
             .ok_or(ValidateContextError::InvalidBurn)?
-            .with_change(burn_change)
+            .apply_change(burn_change)
             .ok_or(ValidateContextError::InvalidBurn)?;
 
         issued_assets
@@ -49,7 +49,7 @@ pub fn valid_burns_and_issuance(
         let _ = issued_assets.insert(
             asset_base,
             asset_state
-                .with_change(issuance_change)
+                .apply_change(issuance_change)
                 .ok_or(ValidateContextError::InvalidIssuance)?,
         );
     }

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -2,45 +2,67 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use zebra_chain::orchard_zsa::IssuedAssets;
+use zebra_chain::orchard_zsa::{AssetBase, AssetState, IssuedAssets};
 
 use crate::{SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
 
 use super::Chain;
+
+// TODO: Factor out chain/disk read to a fn in the `read` module.
+fn asset_state(
+    finalized_state: &ZebraDb,
+    parent_chain: &Arc<Chain>,
+    issued_assets: &HashMap<AssetBase, AssetState>,
+    asset_base: &AssetBase,
+) -> Option<AssetState> {
+    issued_assets
+        .get(asset_base)
+        .copied()
+        .or_else(|| parent_chain.issued_asset(asset_base))
+        .or_else(|| finalized_state.issued_asset(asset_base))
+}
 
 pub fn valid_burns_and_issuance(
     finalized_state: &ZebraDb,
     parent_chain: &Arc<Chain>,
     semantically_verified: &SemanticallyVerifiedBlock,
 ) -> Result<IssuedAssets, ValidateContextError> {
-    let Some(issued_assets_change) = semantically_verified.issued_assets_change.clone() else {
-        return Ok(IssuedAssets::default());
-    };
-
     let mut issued_assets = HashMap::new();
 
-    for (asset_base, change) in issued_assets_change {
-        let asset_state = issued_assets
-            .get(&asset_base)
-            .copied()
-            .or_else(|| parent_chain.issued_asset(&asset_base))
-            .or_else(|| finalized_state.issued_asset(&asset_base));
+    for (issued_assets_change, transaction) in semantically_verified
+        .issued_assets_changes
+        .iter()
+        .zip(&semantically_verified.block.transactions)
+    {
+        // Check that no burn item attempts to burn more than the issued supply for an asset
+        for burn in transaction.orchard_burns() {
+            let asset_base = burn.asset();
+            let asset_state =
+                asset_state(finalized_state, parent_chain, &issued_assets, &asset_base)
+                    .ok_or(ValidateContextError::InvalidBurn)?;
 
-        let updated_asset_state = if change.is_burn() {
-            asset_state
-                .ok_or(ValidateContextError::InvalidBurn)?
-                .apply_change(change)
-                .ok_or(ValidateContextError::InvalidBurn)?
-        } else {
-            asset_state
-                .unwrap_or_default()
-                .apply_change(change)
-                .ok_or(ValidateContextError::InvalidIssuance)?
-        };
+            if asset_state.total_supply < burn.amount() {
+                return Err(ValidateContextError::InvalidBurn);
+            } else {
+                // Any burned asset bases in the transaction will also be present in the issued assets change,
+                // adding a copy of initial asset state to `issued_assets` avoids duplicate disk reads.
+                issued_assets.insert(asset_base, asset_state);
+            }
+        }
 
-        issued_assets
-            .insert(asset_base, updated_asset_state)
-            .expect("transactions must have only one burn item per asset base");
+        for (asset_base, change) in issued_assets_change.iter() {
+            let asset_state =
+                asset_state(finalized_state, parent_chain, &issued_assets, &asset_base)
+                    .unwrap_or_default();
+
+            let updated_asset_state = asset_state
+                .apply_change(change)
+                .ok_or(ValidateContextError::InvalidIssuance)?;
+
+            issued_assets
+                .insert(asset_base, updated_asset_state)
+                .expect("transactions must have only one burn item per asset base");
+        }
     }
 
     Ok(issued_assets.into())

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use zebra_chain::orchard_zsa::IssuedAssets;
 
-use crate::{IssuedAssetsOrChanges, SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
+use crate::{SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
 
 use super::Chain;
 
@@ -13,45 +13,34 @@ pub fn valid_burns_and_issuance(
     parent_chain: &Arc<Chain>,
     semantically_verified: &SemanticallyVerifiedBlock,
 ) -> Result<IssuedAssets, ValidateContextError> {
-    let IssuedAssetsOrChanges::BurnAndIssuanceChanges { burns, issuance } =
-        semantically_verified.issued_assets_changes.clone()
-    else {
-        panic!("unexpected variant in semantically verified block")
+    let Some(issued_assets_change) = semantically_verified.issued_assets_change.clone() else {
+        return Ok(IssuedAssets::default());
     };
 
     let mut issued_assets = HashMap::new();
 
-    for (asset_base, burn_change) in burns.clone() {
-        // TODO: Move this to a read fn.
-        let updated_asset_state = parent_chain
-            .issued_asset(&asset_base)
-            .or_else(|| finalized_state.issued_asset(&asset_base))
-            .ok_or(ValidateContextError::InvalidBurn)?
-            .apply_change(burn_change)
-            .ok_or(ValidateContextError::InvalidBurn)?;
+    for (asset_base, change) in issued_assets_change {
+        let asset_state = issued_assets
+            .get(&asset_base)
+            .copied()
+            .or_else(|| parent_chain.issued_asset(&asset_base))
+            .or_else(|| finalized_state.issued_asset(&asset_base));
+
+        let updated_asset_state = if change.is_burn() {
+            asset_state
+                .ok_or(ValidateContextError::InvalidBurn)?
+                .apply_change(change)
+                .ok_or(ValidateContextError::InvalidBurn)?
+        } else {
+            asset_state
+                .unwrap_or_default()
+                .apply_change(change)
+                .ok_or(ValidateContextError::InvalidIssuance)?
+        };
 
         issued_assets
             .insert(asset_base, updated_asset_state)
             .expect("transactions must have only one burn item per asset base");
-    }
-
-    for (asset_base, issuance_change) in issuance.clone() {
-        // TODO: Move this to a read fn.
-        let Some(asset_state) = issued_assets
-            .get(&asset_base)
-            .copied()
-            .or_else(|| parent_chain.issued_asset(&asset_base))
-            .or_else(|| finalized_state.issued_asset(&asset_base))
-        else {
-            continue;
-        };
-
-        let _ = issued_assets.insert(
-            asset_base,
-            asset_state
-                .apply_change(issuance_change)
-                .ok_or(ValidateContextError::InvalidIssuance)?,
-        );
     }
 
     Ok(issued_assets.into())

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -1,0 +1,58 @@
+//! Checks for issuance and burn validity.
+
+use std::{collections::HashMap, sync::Arc};
+
+use zebra_chain::orchard_zsa::IssuedAssets;
+
+use crate::{IssuedAssetsOrChanges, SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
+
+use super::Chain;
+
+pub fn valid_burns_and_issuance(
+    finalized_state: &ZebraDb,
+    parent_chain: &Arc<Chain>,
+    semantically_verified: &SemanticallyVerifiedBlock,
+) -> Result<IssuedAssets, ValidateContextError> {
+    let IssuedAssetsOrChanges::BurnAndIssuanceChanges { burns, issuance } =
+        semantically_verified.issued_assets_changes.clone()
+    else {
+        panic!("unexpected variant in semantically verified block")
+    };
+
+    let mut issued_assets = HashMap::new();
+
+    for (asset_base, burn_change) in burns.clone() {
+        // TODO: Move this to a read fn.
+        let updated_asset_state = parent_chain
+            .issued_asset(&asset_base)
+            .or_else(|| finalized_state.issued_asset(&asset_base))
+            .ok_or(ValidateContextError::InvalidBurn)?
+            .with_change(burn_change)
+            .ok_or(ValidateContextError::InvalidBurn)?;
+
+        issued_assets
+            .insert(asset_base, updated_asset_state)
+            .expect("transactions must have only one burn item per asset base");
+    }
+
+    for (asset_base, issuance_change) in issuance.clone() {
+        // TODO: Move this to a read fn.
+        let Some(asset_state) = issued_assets
+            .get(&asset_base)
+            .copied()
+            .or_else(|| parent_chain.issued_asset(&asset_base))
+            .or_else(|| finalized_state.issued_asset(&asset_base))
+        else {
+            continue;
+        };
+
+        let _ = issued_assets.insert(
+            asset_base,
+            asset_state
+                .with_change(issuance_change)
+                .ok_or(ValidateContextError::InvalidIssuance)?,
+        );
+    }
+
+    Ok(issued_assets.into())
+}

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -91,6 +91,7 @@ pub const STATE_COLUMN_FAMILIES_IN_CODE: &[&str] = &[
     "orchard_anchors",
     "orchard_note_commitment_tree",
     "orchard_note_commitment_subtree",
+    "orchard_issued_assets",
     // Chain
     "history_tree",
     "tip_chain_value_pool",

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -233,7 +233,7 @@ impl FromDisk for AssetState {
 
         Self {
             is_finalized: is_finalized_byte != 0,
-            total_supply: u64::from_be_bytes(total_supply_bytes).into(),
+            total_supply: u64::from_be_bytes(total_supply_bytes),
         }
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/shielded.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/shielded.rs
@@ -9,7 +9,9 @@ use bincode::Options;
 
 use zebra_chain::{
     block::Height,
-    orchard, sapling, sprout,
+    orchard,
+    orchard_zsa::{AssetBase, AssetState},
+    sapling, sprout,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
 };
 
@@ -205,5 +207,48 @@ impl<Node: FromDisk> FromDisk for NoteCommitmentSubtreeData<Node> {
             Height::from_bytes(height_bytes),
             Node::from_bytes(node_bytes),
         )
+    }
+}
+
+// TODO: Replace `.unwrap()`s with `.expect()`s
+
+impl IntoDisk for AssetState {
+    type Bytes = [u8; 9];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        [
+            vec![self.is_finalized as u8],
+            self.total_supply.to_be_bytes().to_vec(),
+        ]
+        .concat()
+        .try_into()
+        .unwrap()
+    }
+}
+
+impl FromDisk for AssetState {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        let (&is_finalized_byte, bytes) = bytes.as_ref().split_first().unwrap();
+        let (&total_supply_bytes, _bytes) = bytes.split_first_chunk().unwrap();
+
+        Self {
+            is_finalized: is_finalized_byte != 0,
+            total_supply: u64::from_be_bytes(total_supply_bytes).into(),
+        }
+    }
+}
+
+impl IntoDisk for AssetBase {
+    type Bytes = [u8; 32];
+
+    fn as_bytes(&self) -> Self::Bytes {
+        self.to_bytes()
+    }
+}
+
+impl FromDisk for AssetBase {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
+        let (asset_base_bytes, _) = bytes.as_ref().split_first_chunk().unwrap();
+        Self::from_bytes(asset_base_bytes).unwrap()
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/column_family_names.snap
@@ -12,6 +12,7 @@ expression: cf_names
   "height_by_hash",
   "history_tree",
   "orchard_anchors",
+  "orchard_issued_assets",
   "orchard_note_commitment_subtree",
   "orchard_note_commitment_tree",
   "orchard_nullifiers",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_0.snap
@@ -5,6 +5,7 @@ expression: empty_column_families
 [
   "balance_by_transparent_addr: no entries",
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_1.snap
@@ -4,6 +4,7 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@mainnet_2.snap
@@ -4,6 +4,7 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@no_blocks.snap
@@ -11,6 +11,7 @@ expression: empty_column_families
   "height_by_hash: no entries",
   "history_tree: no entries",
   "orchard_anchors: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_note_commitment_tree: no entries",
   "orchard_nullifiers: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_0.snap
@@ -5,6 +5,7 @@ expression: empty_column_families
 [
   "balance_by_transparent_addr: no entries",
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_1.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_1.snap
@@ -4,6 +4,7 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_2.snap
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshots/empty_column_families@testnet_2.snap
@@ -4,6 +4,7 @@ expression: empty_column_families
 ---
 [
   "history_tree: no entries",
+  "orchard_issued_assets: no entries",
   "orchard_note_commitment_subtree: no entries",
   "orchard_nullifiers: no entries",
   "sapling_note_commitment_subtree: no entries",

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -463,7 +463,7 @@ impl DiskWriteBatch {
         // which is already present from height 1 to the first shielded transaction.
         //
         // In Zebra we include the nullifiers and note commitments in the genesis block because it simplifies our code.
-        self.prepare_shielded_transaction_batch(db, finalized)?;
+        self.prepare_shielded_transaction_batch(zebra_db, finalized)?;
         self.prepare_trees_batch(zebra_db, finalized, prev_note_commitment_trees)?;
 
         // # Consensus

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -20,6 +20,7 @@ use zebra_chain::{
         },
         Block, Height,
     },
+    orchard_zsa::IssuedAssetsChange,
     parameters::Network::{self, *},
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transparent::new_ordered_outputs_with_height,
@@ -129,6 +130,8 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
+            let (issued_assets_burns_change, issued_assets_issuance_change) =
+                IssuedAssetsChange::from_block(&original_block);
 
             CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
                 block: original_block.clone(),
@@ -137,6 +140,8 @@ fn test_block_db_round_trip_with(
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: None,
+                issued_assets_burns_change,
+                issued_assets_issuance_change,
             })
         };
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -29,7 +29,7 @@ use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
     constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
-    request::{FinalizedBlock, IssuedAssetsOrChanges, Treestate},
+    request::{FinalizedBlock, Treestate},
     service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb, STATE_COLUMN_FAMILIES_IN_CODE},
     CheckpointVerifiedBlock, Config, SemanticallyVerifiedBlock,
 };
@@ -130,8 +130,9 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
-            let (burns, issuance) =
-                IssuedAssetsChange::from_transactions(&original_block.transactions);
+            let issued_assets_change =
+                IssuedAssetsChange::from_transactions(&original_block.transactions)
+                    .expect("issued assets should be valid");
 
             CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
                 block: original_block.clone(),
@@ -140,10 +141,7 @@ fn test_block_db_round_trip_with(
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: None,
-                issued_assets_changes: IssuedAssetsOrChanges::BurnAndIssuanceChanges {
-                    burns,
-                    issuance,
-                },
+                issued_assets_change: Some(issued_assets_change),
             })
         };
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -29,7 +29,7 @@ use zebra_test::vectors::{MAINNET_BLOCKS, TESTNET_BLOCKS};
 
 use crate::{
     constants::{state_database_format_version_in_code, STATE_DATABASE_KIND},
-    request::{FinalizedBlock, Treestate},
+    request::{FinalizedBlock, IssuedAssetsOrChanges, Treestate},
     service::finalized_state::{disk_db::DiskWriteBatch, ZebraDb, STATE_COLUMN_FAMILIES_IN_CODE},
     CheckpointVerifiedBlock, Config, SemanticallyVerifiedBlock,
 };
@@ -130,8 +130,7 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
-            let (issued_assets_burns_change, issued_assets_issuance_change) =
-                IssuedAssetsChange::from_block(&original_block);
+            let (burns, issuance) = IssuedAssetsChange::from_block(&original_block);
 
             CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
                 block: original_block.clone(),
@@ -140,8 +139,10 @@ fn test_block_db_round_trip_with(
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: None,
-                issued_assets_burns_change,
-                issued_assets_issuance_change,
+                issued_assets_changes: IssuedAssetsOrChanges::BurnAndIssuanceChanges {
+                    burns,
+                    issuance,
+                },
             })
         };
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -130,7 +130,8 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
-            let (burns, issuance) = IssuedAssetsChange::from_block(&original_block);
+            let (burns, issuance) =
+                IssuedAssetsChange::from_transactions(&original_block.transactions);
 
             CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
                 block: original_block.clone(),

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -130,7 +130,7 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
-            let issued_assets_change =
+            let issued_assets_changes =
                 IssuedAssetsChange::from_transactions(&original_block.transactions)
                     .expect("issued assets should be valid");
 
@@ -141,7 +141,7 @@ fn test_block_db_round_trip_with(
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: None,
-                issued_assets_change: Some(issued_assets_change),
+                issued_assets_changes,
             })
         };
 

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -520,7 +520,7 @@ impl DiskWriteBatch {
         let mut batch = zebra_db.issued_assets_cf().with_batch_for_writing(self);
 
         let updated_issued_assets = match issued_assets_or_changes.clone().combine() {
-            IssuedAssetsOrChanges::State(issued_assets) => issued_assets,
+            IssuedAssetsOrChanges::Updated(issued_assets) => issued_assets,
             IssuedAssetsOrChanges::Change(issued_assets_change) => issued_assets_change
                 .apply_with(|asset_base| zebra_db.issued_asset(&asset_base).unwrap_or_default()),
             IssuedAssetsOrChanges::BurnAndIssuanceChanges { .. } => {

--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -19,7 +19,8 @@ use std::{
 
 use zebra_chain::{
     block::Height,
-    orchard,
+    orchard::{self},
+    orchard_zsa::{AssetBase, AssetState},
     parallel::tree::NoteCommitmentTrees,
     sapling, sprout,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
@@ -33,14 +34,31 @@ use crate::{
         disk_format::RawBytes,
         zebra_db::ZebraDb,
     },
-    BoxError,
+    BoxError, IssuedAssetsOrChanges, TypedColumnFamily,
 };
 
 // Doc-only items
 #[allow(unused_imports)]
 use zebra_chain::subtree::NoteCommitmentSubtree;
 
+/// The name of the chain value pools column family.
+///
+/// This constant should be used so the compiler can detect typos.
+pub const ISSUED_ASSETS: &str = "orchard_issued_assets";
+
+/// The type for reading value pools from the database.
+///
+/// This constant should be used so the compiler can detect incorrectly typed accesses to the
+/// column family.
+pub type IssuedAssetsCf<'cf> = TypedColumnFamily<'cf, AssetBase, AssetState>;
+
 impl ZebraDb {
+    /// Returns a typed handle to the `history_tree` column family.
+    pub(crate) fn issued_assets_cf(&self) -> IssuedAssetsCf {
+        IssuedAssetsCf::new(&self.db, ISSUED_ASSETS)
+            .expect("column family was created when database was created")
+    }
+
     // Read shielded methods
 
     /// Returns `true` if the finalized state contains `sprout_nullifier`.
@@ -410,6 +428,11 @@ impl ZebraDb {
         Some(subtree_data.with_index(index))
     }
 
+    /// Get the orchard issued asset state for the finalized tip.
+    pub fn issued_asset(&self, asset_base: &AssetBase) -> Option<AssetState> {
+        self.issued_assets_cf().zs_get(asset_base)
+    }
+
     /// Returns the shielded note commitment trees of the finalized tip
     /// or the empty trees if the state is empty.
     /// Additionally, returns the sapling and orchard subtrees for the finalized tip if
@@ -437,15 +460,17 @@ impl DiskWriteBatch {
     /// - Propagates any errors from updating note commitment trees
     pub fn prepare_shielded_transaction_batch(
         &mut self,
-        db: &DiskDb,
+        zebra_db: &ZebraDb,
         finalized: &FinalizedBlock,
     ) -> Result<(), BoxError> {
         let FinalizedBlock { block, .. } = finalized;
 
         // Index each transaction's shielded data
         for transaction in &block.transactions {
-            self.prepare_nullifier_batch(db, transaction)?;
+            self.prepare_nullifier_batch(&zebra_db.db, transaction)?;
         }
+
+        self.prepare_issued_assets_batch(zebra_db, &finalized.issued_assets)?;
 
         Ok(())
     }
@@ -475,6 +500,36 @@ impl DiskWriteBatch {
         }
         for orchard_nullifier in transaction.orchard_nullifiers() {
             self.zs_insert(&orchard_nullifiers, orchard_nullifier, ());
+        }
+
+        Ok(())
+    }
+
+    /// Prepare a database batch containing `finalized.block`'s asset issuance
+    /// and return it (without actually writing anything).
+    ///
+    /// # Errors
+    ///
+    /// - This method doesn't currently return any errors, but it might in future
+    #[allow(clippy::unwrap_in_result)]
+    pub fn prepare_issued_assets_batch(
+        &mut self,
+        zebra_db: &ZebraDb,
+        issued_assets_or_changes: &IssuedAssetsOrChanges,
+    ) -> Result<(), BoxError> {
+        let mut batch = zebra_db.issued_assets_cf().with_batch_for_writing(self);
+
+        let updated_issued_assets = match issued_assets_or_changes.clone().combine() {
+            IssuedAssetsOrChanges::State(issued_assets) => issued_assets,
+            IssuedAssetsOrChanges::Change(issued_assets_change) => issued_assets_change
+                .apply_with(|asset_base| zebra_db.issued_asset(&asset_base).unwrap_or_default()),
+            IssuedAssetsOrChanges::BurnAndIssuanceChanges { .. } => {
+                panic!("unexpected variant returned from `combine()`")
+            }
+        };
+
+        for (asset_base, updated_issued_asset_state) in updated_issued_assets {
+            batch = batch.zs_insert(&asset_base, &updated_issued_asset_state);
         }
 
         Ok(())

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -325,7 +325,7 @@ impl NonFinalizedState {
             finalized_state,
         )?;
 
-        let _issued_assets =
+        let issued_assets =
             check::issuance::valid_burns_and_issuance(finalized_state, &new_chain, &prepared)?;
 
         // Reads from disk
@@ -346,6 +346,8 @@ impl NonFinalizedState {
         let contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
             prepared.clone(),
             spent_utxos.clone(),
+            // TODO: Refactor this into repeated `With::with()` calls, see http_request_compatibility module.
+            issued_assets,
         )
         .map_err(|value_balance_error| {
             ValidateContextError::CalculateBlockChainValueChange {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -325,6 +325,9 @@ impl NonFinalizedState {
             finalized_state,
         )?;
 
+        let _issued_assets =
+            check::issuance::valid_burns_and_issuance(finalized_state, &new_chain, &prepared)?;
+
         // Reads from disk
         check::anchors::block_sapling_orchard_anchors_refer_to_final_treestates(
             finalized_state,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -972,13 +972,17 @@ impl Chain {
             }
         } else {
             trace!(?position, "reverting changes to issued assets");
-            for (asset_base, change) in IssuedAssetsChange::from_transactions(transactions)
+            for issued_assets_change in IssuedAssetsChange::from_transactions(transactions)
                 .expect("blocks in chain state must be valid")
+                .iter()
+                .rev()
             {
-                self.issued_assets
-                    .entry(asset_base)
-                    .or_default()
-                    .revert_change(change);
+                for (asset_base, change) in issued_assets_change.iter() {
+                    self.issued_assets
+                        .entry(asset_base)
+                        .or_default()
+                        .revert_change(change);
+                }
             }
         }
     }

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -177,6 +177,11 @@ pub struct ChainInner {
     pub(crate) orchard_subtrees:
         BTreeMap<NoteCommitmentSubtreeIndex, NoteCommitmentSubtreeData<orchard::tree::Node>>,
 
+    /// A partial map of `issued_assets` with entries for asset states that were updated in
+    /// this chain.
+    // TODO: Add reference to ZIP
+    pub(crate) issued_assets: HashMap<AssetBase, AssetState>,
+
     // Nullifiers
     //
     /// The Sprout nullifiers revealed by `blocks`.
@@ -240,6 +245,7 @@ impl Chain {
             orchard_anchors_by_height: Default::default(),
             orchard_trees_by_height: Default::default(),
             orchard_subtrees: Default::default(),
+            issued_assets: Default::default(),
             sprout_nullifiers: Default::default(),
             sapling_nullifiers: Default::default(),
             orchard_nullifiers: Default::default(),
@@ -942,9 +948,8 @@ impl Chain {
 
     /// Returns the Orchard issued asset state if one is present in
     /// the chain for the provided asset base.
-    pub fn issued_asset(&self, _asset_base: &AssetBase) -> Option<AssetState> {
-        // self.orchard_issued_assets.get(asset_base).cloned()
-        None
+    pub fn issued_asset(&self, asset_base: &AssetBase) -> Option<AssetState> {
+        self.issued_assets.get(asset_base).cloned()
     }
 
     /// Adds the Orchard `tree` to the tree and anchor indexes at `height`.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -16,13 +16,16 @@ use zebra_chain::{
     block::{self, Height},
     history_tree::HistoryTree,
     orchard,
+    orchard_zsa::{AssetBase, AssetState},
     parallel::tree::NoteCommitmentTrees,
     parameters::Network,
     primitives::Groth16Proof,
     sapling, sprout,
     subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
-    transaction::Transaction::*,
-    transaction::{self, Transaction},
+    transaction::{
+        self,
+        Transaction::{self, *},
+    },
     transparent,
     value_balance::ValueBalance,
     work::difficulty::PartialCumulativeWork,
@@ -935,6 +938,13 @@ impl Chain {
         } else {
             None
         }
+    }
+
+    /// Returns the Orchard issued asset state if one is present in
+    /// the chain for the provided asset base.
+    pub fn issued_asset(&self, _asset_base: &AssetBase) -> Option<AssetState> {
+        // self.orchard_issued_assets.get(asset_base).cloned()
+        None
     }
 
     /// Adds the Orchard `tree` to the tree and anchor indexes at `height`.

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -972,7 +972,8 @@ impl Chain {
             }
         } else {
             trace!(?position, "reverting changes to issued assets");
-            for (asset_base, change) in IssuedAssetsChange::combined_from_transactions(transactions)
+            for (asset_base, change) in IssuedAssetsChange::from_transactions(transactions)
+                .expect("blocks in chain state must be valid")
             {
                 self.issued_assets
                     .entry(asset_base)

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -52,6 +52,7 @@ fn push_genesis_chain() -> Result<()> {
             ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                     block,
                     only_chain.unspent_utxos(),
+                    Default::default(),
                 )
                 .map_err(|e| (e, chain_values.clone()))
                 .expect("invalid block value pool change");
@@ -148,6 +149,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             let block = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                 block,
                 partial_chain.unspent_utxos(),
+                Default::default()
             )?;
             partial_chain = partial_chain
                 .push(block)
@@ -167,7 +169,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
 
         for block in chain.iter().cloned() {
             let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos())?;
+            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos(), Default::default())?;
 
             // Check some properties of the genesis block and don't push it to the chain.
             if block.height == block::Height(0) {
@@ -210,7 +212,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         // same original full chain.
         for block in chain.iter().skip(fork_at_count).cloned() {
             let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, forked.unspent_utxos())?;
+            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, forked.unspent_utxos(), Default::default())?;
             forked = forked.push(block).expect("forked chain push is valid");
         }
 


### PR DESCRIPTION
This PR tracks issued assets in Zebra's state and uses that state to contextually validate issue actions and asset burns.

It still needs tests, additional documentation, cleanup, and to track information for creating split notes.


### Review

This PR may be easier to review by commit.