### PR TITLE
Adds `getassetstate` RPC method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6034,6 +6034,7 @@ dependencies = [
  "incrementalmerkletree",
  "itertools 0.13.0",
  "jubjub",
+ "k256",
  "lazy_static",
  "nonempty",
  "num-integer",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -157,6 +157,8 @@ rand_chacha = { version = "0.3.1", optional = true }
 
 zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.41", optional = true }
 
+k256 = "0.13.3"
+
 [dev-dependencies]
 # Benchmarks
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -9,7 +9,7 @@ pub(crate) mod arbitrary;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod tests;
 
-mod asset_state;
+pub mod asset_state;
 mod burn;
 mod issuance;
 

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -13,11 +13,10 @@ use crate::transaction::Transaction;
 use super::BurnItem;
 
 // TODO:
-// - Add RPC method for querying asset states
 // - Resolve new FIXMEs related to issued asset states
 
 /// The circulating supply and whether that supply has been finalized.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub struct AssetState {
     /// Indicates whether the asset is finalized such that no more of it can be issued.
     pub is_finalized: bool,

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -12,6 +12,11 @@ use crate::transaction::Transaction;
 
 use super::BurnItem;
 
+// TODO:
+// - Add state request/response variants for querying asset states
+// - Add RPC method for querying asset states
+// - Resolve new FIXMEs related to issued asset states
+
 /// The circulating supply and whether that supply has been finalized.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AssetState {

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -12,9 +12,6 @@ use crate::{serialization::ZcashSerialize, transaction::Transaction};
 
 use super::BurnItem;
 
-// TODO:
-// - Resolve new FIXMEs related to issued asset states
-
 /// The circulating supply and whether that supply has been finalized.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub struct AssetState {
@@ -31,8 +28,7 @@ pub struct AssetState {
 pub struct AssetStateChange {
     /// Whether the asset should be finalized such that no more of it can be issued.
     pub should_finalize: bool,
-    // FIXME: is this a correct comment?
-    /// Whether the asset should be finalized such that no more of it can be issued.
+    /// Whether the asset has been issued in this change.
     pub includes_issuance: bool,
     /// The change in supply from newly issued assets or burned assets, if any.
     pub supply_change: SupplyChange,
@@ -214,7 +210,6 @@ impl AssetStateChange {
             })
             .unwrap_or_default()
             .into_iter()
-            // FIXME: We use 0 as a value - is that correct?
             .map(|asset_base| Self::new(asset_base, SupplyChange::Issuance(0), true));
 
         supply_changes.chain(finalize_changes)

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -13,7 +13,6 @@ use crate::transaction::Transaction;
 use super::BurnItem;
 
 // TODO:
-// - Add state request/response variants for querying asset states
 // - Add RPC method for querying asset states
 // - Resolve new FIXMEs related to issued asset states
 

--- a/zebra-chain/src/orchard_zsa/asset_state.rs
+++ b/zebra-chain/src/orchard_zsa/asset_state.rs
@@ -372,6 +372,17 @@ impl std::ops::Add for IssuedAssetsChange {
         }
     }
 }
+
+impl From<Arc<[IssuedAssetsChange]>> for IssuedAssetsChange {
+    fn from(change: Arc<[IssuedAssetsChange]>) -> Self {
+        change
+            .iter()
+            .cloned()
+            .reduce(|a, b| a + b)
+            .unwrap_or_default()
+    }
+}
+
 /// Used in snapshot test for `getassetstate` RPC method.
 // TODO: Replace with `AssetBase::random()` or a known value.
 pub trait RandomAssetBase {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -42,7 +42,7 @@ use crate::{
         Progress::{self, *},
         TargetHeight::{self, *},
     },
-    error::{BlockError, SubsidyError, TransactionError},
+    error::{BlockError, SubsidyError},
     funding_stream_values, BoxError, ParameterCheckpoint as _,
 };
 
@@ -619,8 +619,7 @@ where
         };
 
         // don't do precalculation until the block passes basic difficulty checks
-        let block = CheckpointVerifiedBlock::new(block, Some(hash), expected_deferred_amount)
-            .ok_or_else(|| VerifyBlockError::from(TransactionError::InvalidAssetIssuanceOrBurn))?;
+        let block = CheckpointVerifiedBlock::new(block, Some(hash), expected_deferred_amount);
 
         crate::block::check::merkle_root_validity(
             &self.network,

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -239,9 +239,6 @@ pub enum TransactionError {
     #[error("failed to verify ZIP-317 transaction rules, transaction was not inserted to mempool")]
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Zip317(#[from] zebra_chain::transaction::zip317::Error),
-
-    #[error("failed to validate asset issuance and/or burns")]
-    InvalidAssetIssuanceOrBurn,
 }
 
 impl From<ValidateContextError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -19,7 +19,6 @@ use tracing::Instrument;
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block, orchard,
-    orchard_zsa::IssuedAssetsChange,
     parameters::{Network, NetworkUpgrade},
     primitives::Groth16Proof,
     sapling,
@@ -144,10 +143,6 @@ pub enum Response {
         /// The number of legacy signature operations in this transaction's
         /// transparent inputs and outputs.
         legacy_sigop_count: u64,
-
-        /// The changes to the issued assets map that should be applied for
-        /// this transaction.
-        issued_assets_change: IssuedAssetsChange,
     },
 
     /// A response to a mempool transaction verification request.
@@ -485,7 +480,6 @@ where
                     tx_id,
                     miner_fee,
                     legacy_sigop_count,
-                    issued_assets_change: IssuedAssetsChange::from_transaction(&tx).ok_or(TransactionError::InvalidAssetIssuanceOrBurn)?,
                 },
                 Request::Mempool { transaction, .. } => {
                     let transaction = VerifiedUnminedTx::new(

--- a/zebra-rpc/src/methods/tests/snapshots/get_asset_state@mainnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_asset_state@mainnet.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: asset_state
+---
+{
+  "is_finalized": true,
+  "total_supply": 1000
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_asset_state@testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_asset_state@testnet.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: asset_state
+---
+{
+  "is_finalized": true,
+  "total_supply": 1000
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_asset_state_not_found@mainnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_asset_state_not_found@mainnet.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: asset_state
+---
+{
+  "code": 0,
+  "message": "asset base not found"
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_asset_state_not_found@testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_asset_state_not_found@testnet.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: asset_state
+---
+{
+  "code": 0,
+  "message": "asset base not found"
+}

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use zebra_chain::{
     amount::Amount,
     block::{self, Block},
-    orchard_zsa::IssuedAssetsChange,
     transaction::Transaction,
     transparent,
     value_balance::ValueBalance,
@@ -31,8 +30,6 @@ impl Prepare for Arc<Block> {
         let transaction_hashes: Arc<[_]> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs =
             transparent::new_ordered_outputs_with_height(&block, height, &transaction_hashes);
-        let issued_assets_changes = IssuedAssetsChange::from_transactions(&block.transactions)
-            .expect("prepared blocks should be semantically valid");
 
         SemanticallyVerifiedBlock {
             block,
@@ -41,7 +38,6 @@ impl Prepare for Arc<Block> {
             new_outputs,
             transaction_hashes,
             deferred_balance: None,
-            issued_assets_changes,
         }
     }
 }
@@ -120,7 +116,6 @@ impl ContextuallyVerifiedBlock {
             new_outputs,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_changes: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -11,7 +11,7 @@ use zebra_chain::{
     block::{self, Block},
     history_tree::HistoryTree,
     orchard,
-    orchard_zsa::{IssuedAssets, IssuedAssetsChange},
+    orchard_zsa::{AssetBase, IssuedAssets, IssuedAssetsChange},
     parallel::tree::NoteCommitmentTrees,
     sapling,
     serialization::SerializationError,
@@ -1122,6 +1122,17 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::TipBlockSize(usize)`](ReadResponse::TipBlockSize)
     /// with the current best chain tip block size in bytes.
     TipBlockSize,
+
+    #[cfg(feature = "tx-v6")]
+    /// Returns [`ReadResponse::AssetState`] with an [`AssetState`](zebra_chain::orchard_zsa::AssetState)
+    /// of the provided [`AssetBase`] if it exists for the best chain tip or finalized chain tip (depending
+    /// on the `include_non_finalized` flag).
+    AssetState {
+        /// The [`AssetBase`] to return the asset state for.
+        asset_base: AssetBase,
+        /// Whether to include the issued asset state changes in the non-finalized state.
+        include_non_finalized: bool,
+    },
 }
 
 impl ReadRequest {
@@ -1159,6 +1170,8 @@ impl ReadRequest {
             ReadRequest::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::TipBlockSize => "tip_block_size",
+            #[cfg(feature = "tx-v6")]
+            ReadRequest::AssetState { .. } => "asset_state",
         }
     }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -5,7 +5,9 @@ use std::{collections::BTreeMap, sync::Arc};
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block},
-    orchard, sapling,
+    orchard,
+    orchard_zsa::AssetState,
+    sapling,
     serialization::DateTime32,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
     transaction::{self, Transaction},
@@ -233,6 +235,10 @@ pub enum ReadResponse {
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::TipBlockSize`]
     TipBlockSize(Option<usize>),
+
+    #[cfg(feature = "tx-v6")]
+    /// Response to [`ReadRequest::AssetState`]
+    AssetState(Option<AssetState>),
 }
 
 /// A structure with the information needed from the state to build a `getblocktemplate` RPC response.
@@ -322,6 +328,9 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::ChainInfo(_) | ReadResponse::SolutionRate(_) | ReadResponse::TipBlockSize(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
+
+            #[cfg(feature = "tx-v6")]
+            ReadResponse::AssetState(_) => Err("there is no corresponding Response for this ReadResponse"),
         }
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1947,6 +1947,30 @@ impl Service<ReadRequest> for ReadStateService {
                 })
                 .wait_for_panics()
             }
+
+            #[cfg(feature = "tx-v6")]
+            ReadRequest::AssetState {
+                asset_base,
+                include_non_finalized,
+            } => {
+                let state = self.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let best_chain = include_non_finalized
+                            .then(|| state.latest_best_chain())
+                            .flatten();
+
+                        let response = read::asset_state(best_chain, &state.db, &asset_base);
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::AssetState");
+
+                        Ok(ReadResponse::AssetState(response))
+                    })
+                })
+                .wait_for_panics()
+            }
         }
     }
 }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -116,7 +116,6 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             new_outputs: _,
             transaction_hashes,
             deferred_balance: _,
-            issued_assets_changes: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -4,23 +4,9 @@ use std::{collections::HashMap, sync::Arc};
 
 use zebra_chain::orchard_zsa::{AssetBase, AssetState, IssuedAssets};
 
-use crate::{SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
+use crate::{service::read, SemanticallyVerifiedBlock, ValidateContextError, ZebraDb};
 
 use super::Chain;
-
-// TODO: Factor out chain/disk read to a fn in the `read` module.
-fn asset_state(
-    finalized_state: &ZebraDb,
-    parent_chain: &Arc<Chain>,
-    issued_assets: &HashMap<AssetBase, AssetState>,
-    asset_base: &AssetBase,
-) -> Option<AssetState> {
-    issued_assets
-        .get(asset_base)
-        .copied()
-        .or_else(|| parent_chain.issued_asset(asset_base))
-        .or_else(|| finalized_state.issued_asset(asset_base))
-}
 
 pub fn valid_burns_and_issuance(
     finalized_state: &ZebraDb,
@@ -83,4 +69,16 @@ pub fn valid_burns_and_issuance(
     }
 
     Ok(issued_assets.into())
+}
+
+fn asset_state(
+    finalized_state: &ZebraDb,
+    parent_chain: &Arc<Chain>,
+    issued_assets: &HashMap<AssetBase, AssetState>,
+    asset_base: &AssetBase,
+) -> Option<AssetState> {
+    issued_assets
+        .get(asset_base)
+        .copied()
+        .or_else(|| read::asset_state(Some(parent_chain), finalized_state, asset_base))
 }

--- a/zebra-state/src/service/check/issuance.rs
+++ b/zebra-state/src/service/check/issuance.rs
@@ -15,8 +15,8 @@ pub fn valid_burns_and_issuance(
 ) -> Result<IssuedAssets, ValidateContextError> {
     let mut issued_assets = HashMap::new();
 
-    // FIXME: Do all checks (for duplication, existence etc.) need to be performed per tranaction, not per
-    // the entire block?
+    // Burns need to be checked and asset state changes need to be applied per tranaction, in case
+    // the asset being burned was also issued in an earlier transaction in the same block.
     for (issued_assets_change, transaction) in semantically_verified
         .issued_assets_changes
         .iter()
@@ -27,12 +27,10 @@ pub fn valid_burns_and_issuance(
             let asset_base = burn.asset();
             let asset_state =
                 asset_state(finalized_state, parent_chain, &issued_assets, &asset_base)
+                    // The asset being burned should have been issued by a previous transaction, and
+                    // any assets issued in previous transactions should be present in the issued assets map.
                     .ok_or(ValidateContextError::InvalidBurn)?;
 
-            // FIXME: The check that we can't burn an asset before we issued it is implicit -
-            // through the check it total_supply < burn.amount (the total supply is zero if the
-            // asset is not issued). May be validation functions from the orcharfd crate need to be
-            // reused in a some way?
             if asset_state.total_supply < burn.raw_amount() {
                 return Err(ValidateContextError::InvalidBurn);
             } else {
@@ -42,13 +40,8 @@ pub fn valid_burns_and_issuance(
             }
         }
 
-        // FIXME: Not sure: it looks like semantically_verified.issued_assets_changes is already
-        // filled with burn and issuance items in zebra-consensus, see Verifier::call function in
-        // zebra-consensus/src/transaction.rs (it uses from_burn and from_issue_action AssetStateChange
-        // methods from ebra-chain/src/orchard_zsa/asset_state.rs). Can't it cause a duplication?
-        // Can we collect all change items here, not in zebra-consensus (and so we don't need
-        // SemanticallyVerifiedBlock::issued_assets_changes at all), or performing part of the
-        // checks in zebra-consensus is important for the consensus checks order in a some way?
+        // TODO: Remove the `issued_assets_change` field from `SemanticallyVerifiedBlock` and get the changes
+        //       directly from transactions here and when writing blocks to disk.
         for (asset_base, change) in issued_assets_change.iter() {
             let asset_state =
                 asset_state(finalized_state, parent_chain, &issued_assets, &asset_base)
@@ -58,12 +51,8 @@ pub fn valid_burns_and_issuance(
                 .apply_change(change)
                 .ok_or(ValidateContextError::InvalidIssuance)?;
 
-            // FIXME: Is it correct to do nothing if the issued_assets aready has asset_base? Now it'd be
-            // replaced with updated_asset_state in this case (where the duplicated value is added to
-            // the supply). Block may have two burn records for the same asset but in different
-            // transactions - it's allowed, that's why the check has been removed. On the other
-            // hand, there needs to be a check that denies duplicated burn records for the same
-            // asset inside the same transaction.
+            // TODO: Update `Burn` to `HashMap<AssetBase, NoteValue>)` and return an error during deserialization if
+            //       any asset base is burned twice in the same transaction
             issued_assets.insert(asset_base, updated_asset_state);
         }
     }

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -20,7 +20,6 @@ use zebra_chain::{
         },
         Block, Height,
     },
-    orchard_zsa::IssuedAssetsChange,
     parameters::Network::{self, *},
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transparent::new_ordered_outputs_with_height,
@@ -130,9 +129,6 @@ fn test_block_db_round_trip_with(
                 .collect();
             let new_outputs =
                 new_ordered_outputs_with_height(&original_block, Height(0), &transaction_hashes);
-            let issued_assets_changes =
-                IssuedAssetsChange::from_transactions(&original_block.transactions)
-                    .expect("issued assets should be valid");
 
             CheckpointVerifiedBlock(SemanticallyVerifiedBlock {
                 block: original_block.clone(),
@@ -141,7 +137,6 @@ fn test_block_db_round_trip_with(
                 new_outputs,
                 transaction_hashes,
                 deferred_balance: None,
-                issued_assets_changes,
             })
         };
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -34,8 +34,8 @@ pub use block::{
     any_utxo, block, block_header, mined_transaction, transaction_hashes_for_block, unspent_utxo,
 };
 pub use find::{
-    best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
-    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
+    asset_state, best_tip, block_locator, depth, finalized_state_contains_block_hash,
+    find_chain_hashes, find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use zebra_chain::{
     amount::NonNegative,
     block::{self, Block, Height},
+    orchard_zsa::{AssetBase, AssetState},
     serialization::DateTime32,
     value_balance::ValueBalance,
 };
@@ -678,4 +679,14 @@ pub(crate) fn calculate_median_time_past(relevant_chain: Vec<Arc<Block>>) -> Dat
     let median_time_past = AdjustedDifficulty::median_time(relevant_data);
 
     DateTime32::try_from(median_time_past).expect("valid blocks have in-range times")
+}
+
+/// Return the [`AssetState`] for the provided [`AssetBase`], if it exists in the provided chain.
+pub fn asset_state<C>(chain: Option<C>, db: &ZebraDb, asset_base: &AssetBase) -> Option<AssetState>
+where
+    C: AsRef<Chain>,
+{
+    chain
+        .and_then(|chain| chain.as_ref().issued_asset(asset_base))
+        .or_else(|| db.issued_asset(asset_base))
 }


### PR DESCRIPTION
Adds an RPC method for querying issued asset states by asset base (in the first 4 commits).

Begins simplifying validation and state update logic.