### PR TITLE
First-stage ZSA integration: apply upstream feedback & refactoring (#9560)

### DIFF
--- a/zebra-chain/src/orchard.rs
+++ b/zebra-chain/src/orchard.rs
@@ -26,7 +26,5 @@ pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
 pub use shielded_data::{AuthorizedAction, Flags, ShieldedData};
 pub use shielded_data_flavor::{OrchardVanilla, ShieldedDataFlavor};
 
-pub(crate) use shielded_data::ActionCommon;
-
 #[cfg(feature = "tx-v6")]
 pub use shielded_data_flavor::OrchardZSA;

--- a/zebra-chain/src/orchard/note/arbitrary.rs
+++ b/zebra-chain/src/orchard/note/arbitrary.rs
@@ -2,13 +2,13 @@ use proptest::{collection::vec, prelude::*};
 
 use super::*;
 
-impl<const N: usize> Arbitrary for EncryptedNote<N> {
+impl<const SIZE: usize> Arbitrary for EncryptedNote<SIZE> {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (vec(any::<u8>(), N))
+        (vec(any::<u8>(), SIZE))
             .prop_map(|v| {
-                let mut bytes = [0; N];
+                let mut bytes = [0; SIZE];
                 bytes.copy_from_slice(v.as_slice());
                 Self(bytes)
             })

--- a/zebra-chain/src/orchard/note/ciphertexts.rs
+++ b/zebra-chain/src/orchard/note/ciphertexts.rs
@@ -10,21 +10,21 @@ use crate::serialization::{SerializationError, ZcashDeserialize, ZcashSerialize}
 ///
 /// Corresponds to the Orchard 'encCiphertext's
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
-pub struct EncryptedNote<const N: usize>(#[serde(with = "BigArray")] pub(crate) [u8; N]);
+pub struct EncryptedNote<const SIZE: usize>(#[serde(with = "BigArray")] pub(crate) [u8; SIZE]);
 
-impl<const N: usize> From<[u8; N]> for EncryptedNote<N> {
-    fn from(bytes: [u8; N]) -> Self {
+impl<const SIZE: usize> From<[u8; SIZE]> for EncryptedNote<SIZE> {
+    fn from(bytes: [u8; SIZE]) -> Self {
         Self(bytes)
     }
 }
 
-impl<const N: usize> From<EncryptedNote<N>> for [u8; N] {
-    fn from(enc_ciphertext: EncryptedNote<N>) -> Self {
+impl<const SIZE: usize> From<EncryptedNote<SIZE>> for [u8; SIZE] {
+    fn from(enc_ciphertext: EncryptedNote<SIZE>) -> Self {
         enc_ciphertext.0
     }
 }
 
-impl<const N: usize> TryFrom<&[u8]> for EncryptedNote<N> {
+impl<const SIZE: usize> TryFrom<&[u8]> for EncryptedNote<SIZE> {
     type Error = std::array::TryFromSliceError;
 
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
@@ -32,16 +32,16 @@ impl<const N: usize> TryFrom<&[u8]> for EncryptedNote<N> {
     }
 }
 
-impl<const N: usize> ZcashSerialize for EncryptedNote<N> {
+impl<const SIZE: usize> ZcashSerialize for EncryptedNote<SIZE> {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         writer.write_all(&self.0[..])?;
         Ok(())
     }
 }
 
-impl<const N: usize> ZcashDeserialize for EncryptedNote<N> {
+impl<const SIZE: usize> ZcashDeserialize for EncryptedNote<SIZE> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; N];
+        let mut bytes = [0; SIZE];
         reader.read_exact(&mut bytes[..])?;
         Ok(Self(bytes))
     }

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -21,6 +21,9 @@ use crate::{
 };
 
 #[cfg(feature = "tx-v6")]
+use crate::orchard_zsa::compute_burn_value_commitment;
+
+#[cfg(feature = "tx-v6")]
 use orchard::{note::AssetBase, value::ValueSum};
 
 use super::{OrchardVanilla, ShieldedDataFlavor};
@@ -142,7 +145,7 @@ impl<Flavor: ShieldedDataFlavor> ShieldedData<Flavor> {
                 (ValueSum::default() + i64::from(self.value_balance)).unwrap(),
                 AssetBase::native(),
             );
-            let burn_value_commitment = self.burn.clone().into();
+            let burn_value_commitment = compute_burn_value_commitment(&self.burn);
             cv - cv_balance - burn_value_commitment
         };
 

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -90,12 +90,6 @@ impl<Flavor: ShieldedDataFlavor> ShieldedData<Flavor> {
         self.actions.actions()
     }
 
-    /// Return an iterator for the [`ActionCommon`] copy of the Actions in this
-    /// transaction, in the order they appear in it.
-    pub fn action_commons(&self) -> impl Iterator<Item = ActionCommon> + '_ {
-        self.actions.actions().map(|action| action.into())
-    }
-
     /// Collect the [`Nullifier`]s for this transaction.
     pub fn nullifiers(&self) -> impl Iterator<Item = &Nullifier> {
         self.actions().map(|action| &action.nullifier)
@@ -259,29 +253,6 @@ impl<Flavor: ShieldedDataFlavor> AuthorizedAction<Flavor> {
         AuthorizedAction {
             action,
             spend_auth_sig,
-        }
-    }
-}
-
-/// The common field used both in Vanilla actions and ZSA actions.
-pub struct ActionCommon {
-    /// A value commitment to net value of the input note minus the output note
-    pub cv: ValueCommitment,
-    /// The nullifier of the input note being spent.
-    pub nullifier: super::note::Nullifier,
-    /// The randomized validating key for spendAuthSig,
-    pub rk: reddsa::VerificationKeyBytes<SpendAuth>,
-    /// The x-coordinate of the note commitment for the output note.
-    pub cm_x: pallas::Base,
-}
-
-impl<Flavor: ShieldedDataFlavor> From<&Action<Flavor>> for ActionCommon {
-    fn from(action: &Action<Flavor>) -> Self {
-        Self {
-            cv: action.cv,
-            nullifier: action.nullifier,
-            rk: action.rk,
-            cm_x: action.cm_x,
         }
     }
 }

--- a/zebra-chain/src/orchard/shielded_data_flavor.rs
+++ b/zebra-chain/src/orchard/shielded_data_flavor.rs
@@ -14,10 +14,7 @@ pub use orchard::{note::AssetBase, orchard_flavor::OrchardZSA, value::NoteValue}
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 
 #[cfg(feature = "tx-v6")]
-use crate::{
-    orchard::ValueCommitment,
-    orchard_zsa::{Burn, BurnItem, NoBurn},
-};
+use crate::orchard_zsa::{Burn, BurnItem, NoBurn};
 
 use super::note;
 
@@ -60,7 +57,6 @@ pub trait ShieldedDataFlavor: OrchardFlavor {
         + Default
         + ZcashDeserialize
         + ZcashSerialize
-        + Into<ValueCommitment>
         + AsRef<[BurnItem]>
         + for<'a> From<&'a [(AssetBase, NoteValue)]>
         + test_arbitrary::TestArbitrary;

--- a/zebra-chain/src/orchard/shielded_data_flavor.rs
+++ b/zebra-chain/src/orchard/shielded_data_flavor.rs
@@ -51,10 +51,8 @@ pub trait ShieldedDataFlavor: OrchardFlavor {
 
     /// A type representing a burn field for this protocol version.
     #[cfg(feature = "tx-v6")]
-    // FIXME: try to get rid
     type BurnType: Clone
         + Debug
-        + Default
         + ZcashDeserialize
         + ZcashSerialize
         + AsRef<[BurnItem]>

--- a/zebra-chain/src/orchard_zsa.rs
+++ b/zebra-chain/src/orchard_zsa.rs
@@ -6,5 +6,5 @@ mod arbitrary;
 mod burn;
 mod issuance;
 
-pub(crate) use burn::{Burn, BurnItem, NoBurn};
+pub(crate) use burn::{compute_burn_value_commitment, Burn, BurnItem, NoBurn};
 pub(crate) use issuance::IssueData;

--- a/zebra-chain/src/orchard_zsa/burn.rs
+++ b/zebra-chain/src/orchard_zsa/burn.rs
@@ -100,16 +100,6 @@ impl From<&[(AssetBase, NoteValue)]> for NoBurn {
     }
 }
 
-impl From<NoBurn> for ValueCommitment {
-    fn from(_burn: NoBurn) -> ValueCommitment {
-        ValueCommitment::new(
-            pallas::Scalar::zero(),
-            NoteValue::from_raw(0).into(),
-            AssetBase::native(),
-        )
-    }
-}
-
 impl AsRef<[BurnItem]> for NoBurn {
     fn as_ref(&self) -> &[BurnItem] {
         &[]
@@ -149,18 +139,6 @@ impl From<&[(AssetBase, NoteValue)]> for Burn {
     }
 }
 
-impl From<Burn> for ValueCommitment {
-    fn from(burn: Burn) -> ValueCommitment {
-        burn.0
-            .into_iter()
-            .map(|BurnItem(asset, amount)| {
-                // The trapdoor for the burn which is public is always zero.
-                ValueCommitment::new(pallas::Scalar::zero(), amount.into(), asset)
-            })
-            .sum()
-    }
-}
-
 impl AsRef<[BurnItem]> for Burn {
     fn as_ref(&self) -> &[BurnItem] {
         &self.0
@@ -185,4 +163,17 @@ impl ZcashDeserialize for Burn {
                 .collect(),
         ))
     }
+}
+
+pub(crate) fn compute_burn_value_commitment<B>(burn: &B) -> ValueCommitment
+where
+    B: AsRef<[BurnItem]>,
+{
+    burn.as_ref()
+        .iter()
+        .map(|&BurnItem(asset, amount)| {
+            // The trapdoor for the burn which is public is always zero.
+            ValueCommitment::new(pallas::Scalar::zero(), amount.into(), asset)
+        })
+        .sum()
 }

--- a/zebra-chain/src/transaction/unmined/zip317.rs
+++ b/zebra-chain/src/transaction/unmined/zip317.rs
@@ -153,7 +153,7 @@ pub fn conventional_actions(transaction: &Transaction) -> u32 {
     let n_join_split = transaction.joinsplit_count();
     let n_spends_sapling = transaction.sapling_spends_per_anchor().count();
     let n_outputs_sapling = transaction.sapling_outputs().count();
-    let n_actions_orchard = transaction.orchard_actions().count();
+    let n_actions_orchard = transaction.orchard_action_count();
 
     let tx_in_logical_actions = div_ceil(tx_in_total_size, P2PKH_STANDARD_INPUT_SIZE);
     let tx_out_logical_actions = div_ceil(tx_out_total_size, P2PKH_STANDARD_OUTPUT_SIZE);

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -166,7 +166,7 @@ fn v5_transaction_with_no_inputs_fails_validation() {
     .find(|transaction| {
         transaction.inputs().is_empty()
             && transaction.sapling_spends_per_anchor().next().is_none()
-            && transaction.orchard_actions().next().is_none()
+            && transaction.orchard_action_count() == 0
             && transaction.joinsplit_count() == 0
             && (!transaction.outputs().is_empty() || transaction.sapling_outputs().next().is_some())
     })
@@ -800,7 +800,7 @@ fn v5_transaction_with_no_outputs_fails_validation() {
     .find(|transaction| {
         transaction.outputs().is_empty()
             && transaction.sapling_outputs().next().is_none()
-            && transaction.orchard_actions().next().is_none()
+            && transaction.orchard_action_count() == 0
             && transaction.joinsplit_count() == 0
             && (!transaction.inputs().is_empty()
                 || transaction.sapling_spends_per_anchor().next().is_some())
@@ -2795,8 +2795,7 @@ fn coinbase_outputs_are_decryptable_for_historical_blocks_for_network(
 
         // Check if the coinbase outputs are decryptable with an all-zero key.
         if heartwood_onward
-            && (coinbase_tx.sapling_outputs().count() > 0
-                || coinbase_tx.orchard_actions().count() > 0)
+            && (coinbase_tx.sapling_outputs().count() > 0 || coinbase_tx.orchard_action_count() > 0)
         {
             // We are only truly decrypting something if it's Heartwood-onward
             // and there are relevant outputs.
@@ -2808,7 +2807,7 @@ fn coinbase_outputs_are_decryptable_for_historical_blocks_for_network(
         // For remaining transactions, check if existing outputs are NOT decryptable
         // with an all-zero key, if applicable.
         for tx in block.transactions.iter().skip(1) {
-            let has_outputs = tx.sapling_outputs().count() > 0 || tx.orchard_actions().count() > 0;
+            let has_outputs = tx.sapling_outputs().count() > 0 || tx.orchard_action_count() > 0;
             if has_outputs && heartwood_onward {
                 tested_non_coinbase_txs += 1;
                 check::coinbase_outputs_are_decryptable(tx, &network, height).expect_err(


### PR DESCRIPTION
This PR continues the first-stage ZSA integration (Partial ZSA Support: Transaction V6, NU7, generics for backward compatibility, pre-state consensus – see [#9560](https://github.com/ZcashFoundation/zebra/pull/9560)). It consolidates:

- Zcash Foundation review feedback  
- Outcomes from internal discussions  
- Additional refactorings and minor improvements  

**Key updates**

- **BurnType**: Removed the `Default` trait bound and dropped the related `FIXME`.  
- **Orchard actions**: Eliminated `shielded_data::ActionCommon`; replaced `Transaction::orchard_actions()` with `Transaction::orchard_action_count()`.  
- **EncryptedNote**: Renamed generic const parameter `N` to `SIZE` for clarity.  
- **Value commitments**: Replaced `Into<ValueCommitment>` usage for `ShieldedDataFlavor::BurnType` with `compute_burn_value_commitment`.  
