### PR TITLE
Add needed ecs permissions for CICD user

### DIFF
--- a/testnet-single-node-deploy/infra/terraform-aws-modules/cicd-user/main.tf
+++ b/testnet-single-node-deploy/infra/terraform-aws-modules/cicd-user/main.tf
@@ -32,6 +32,8 @@ resource "aws_iam_policy" "ecr_ecs_policy" {
           "ecs:ListServices",
           "ecs:ListTasks",
           "ecs:DescribeTasks",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
           "ecs:RunTask",
           "ecs:StopTask",
           "ecs:StartTask"
@@ -45,6 +47,18 @@ resource "aws_iam_policy" "ecr_ecs_policy" {
           "lambda:*"
         ]
         Resource = "arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:function:watch-zebra-logs"
+      },
+      {
+        # The CICD user needs the iam:PassRole permission to pass the ECS execution role when registering task definitions.
+        Sid    = "AllowPassRole"
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole"
+        ]
+        Resource = [
+          "arn:aws:iam::${var.aws_account_id}:role/${var.env}-zebra-ecs_execution_role",
+          "arn:aws:iam::${var.aws_account_id}:role/${var.env}-zebra-ecs_task_role"
+        ]
       }
     ]
   })


### PR DESCRIPTION
After running the updated [ECS workflow](https://github.com/QED-it/zebra/pull/67/files) changing the docker image in the task definition we saw that extra permissions are needed for the CICD user. This PR adds the minimal needed permissions.