### PR TITLE
Clean up rust-toolchain.toml: remove components and update TODO

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
-# TODO: This file does not exist in the original Zebra repo - consider removing it before the final merge.
+# TODO: Upstream specifies `channel = "stable"` — consider restoring it before final merge.
 [toolchain]
 channel = "1.82.0"
-components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
This PR removes the `components = ["clippy", "rustfmt"]` line and simplifies the TODO to note that upstream uses `channel = "stable"`, which should be restored before the final merge.
