### PR TITLE
Add `gethealthinfo` RPC call and `/health` HTTP endpoint

### DIFF
--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -40,6 +40,9 @@ getblocktemplate-rpcs = [
     "zebra-chain/getblocktemplate-rpcs",
 ]
 
+# Health RPC support
+gethealthinfo-rpc = []
+
 # Experimental internal miner support
 internal-miner = []
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -528,7 +528,7 @@ where
         Ok(GetHealthInfo::snapshot())
     }
 
-    // Dummy type so the trait always compiles when the feature is off.
+    // Dummy impl: return MethodNotFound if the feature is disabled.
     #[cfg(not(feature = "gethealthinfo-rpc"))]
     fn get_health_info(&self) -> Result<GetHealthInfo> {
         Err(jsonrpc_core::Error::method_not_found())

--- a/zebra-rpc/src/methods/tests.rs
+++ b/zebra-rpc/src/methods/tests.rs
@@ -1,6 +1,5 @@
 //! Test code for RPC methods
 
-mod method_names;
 mod prop;
 mod snapshot;
 #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-rpc/src/methods/tests.rs
+++ b/zebra-rpc/src/methods/tests.rs
@@ -1,5 +1,6 @@
 //! Test code for RPC methods
 
+mod method_names;
 mod prop;
 mod snapshot;
 #[cfg(feature = "getblocktemplate-rpcs")]

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -217,6 +217,15 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         return;
     }
 
+    // `gethealthinfo`
+    #[cfg(feature = "gethealthinfo-rpc")]
+    {
+        let get_health_info = rpc
+            .get_health_info()
+            .expect("We should have a GetHealthInfo struct");
+        snapshot_rpc_gethealthinfo(get_health_info, &settings);
+    }
+
     // `getinfo`
     let get_info = rpc.get_info().expect("We should have a GetInfo struct");
     snapshot_rpc_getinfo(get_info, &settings);
@@ -535,6 +544,16 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
     // Check the response.
     settings.bind(|| {
         insta::assert_json_snapshot!(format!("z_get_subtrees_by_index_for_orchard"), subtrees)
+    });
+}
+
+/// Snapshot `gethealthinfo` response, using `cargo insta` and JSON serialization.
+#[cfg(feature = "gethealthinfo-rpc")]
+fn snapshot_rpc_gethealthinfo(info: GetHealthInfo, settings: &insta::Settings) {
+    // Snapshot only the `status` field since other fields vary per build/run.
+    let status_only = serde_json::json!({ "status": info.status });
+    settings.bind(|| {
+        insta::assert_json_snapshot!("get_health_info_status", status_only);
     });
 }
 

--- a/zebra-rpc/src/methods/tests/snapshots/get_health_info_status@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_health_info_status@mainnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 551
+expression: status_only
+---
+{
+  "status": "healthy"
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_health_info_status@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_health_info_status@testnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 551
+expression: status_only
+---
+{
+  "status": "healthy"
+}

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -213,11 +213,16 @@ impl RpcServer {
 
                     // Use a different tokio executor from the rest of Zebra,
                     // so that large RPCs and any task handling bugs don't impact Zebra.
-                    let server_instance = ServerBuilder::new(io)
+                    let builder = ServerBuilder::new(io)
                         .threads(parallel_cpu_threads)
                         // TODO: disable this security check if we see errors from lightwalletd
                         //.allowed_hosts(DomainsValidation::Disabled)
-                        .request_middleware(middleware)
+                        .request_middleware(middleware);
+
+                    #[cfg(feature = "gethealthinfo-rpc")]
+                    let builder = builder.health_api(("health", "gethealthinfo"));
+
+                    let server_instance = builder
                         .start_http(&listen_addr)
                         .expect("Unable to start RPC server");
 

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -220,7 +220,7 @@ impl RpcServer {
                         .request_middleware(middleware);
 
                     #[cfg(feature = "gethealthinfo-rpc")]
-                    let builder = builder.health_api(("health", "gethealthinfo"));
+                    let builder = builder.health_api(("/health", "gethealthinfo"));
 
                     let server_instance = builder
                         .start_http(&listen_addr)

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -52,7 +52,7 @@ features = [
 
 [features]
 # In release builds, don't compile debug logging code, to improve performance.
-default = ["release_max_level_info", "progress-bar", "getblocktemplate-rpcs"]
+default = ["release_max_level_info", "progress-bar", "getblocktemplate-rpcs", "gethealthinfo-rpc"]
 
 # Default features for official ZF binary release builds
 default-release-binaries = ["default", "sentry"]
@@ -69,6 +69,11 @@ getblocktemplate-rpcs = [
     "zebra-state/getblocktemplate-rpcs",
     "zebra-node-services/getblocktemplate-rpcs",
     "zebra-chain/getblocktemplate-rpcs",
+]
+
+# Health RPC support
+gethealthinfo-rpc = [
+    "zebra-rpc/gethealthinfo-rpc"
 ]
 
 # Experimental internal miner support

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1665,7 +1665,6 @@ async fn rpc_endpoint_client_content_type() -> Result<()> {
 
     #[cfg(feature = "gethealthinfo-rpc")]
     {
-        // Just test with plain content type, similar to getinfo.
         let res = client
             .call_with_content_type(
                 "gethealthinfo",


### PR DESCRIPTION
This PR introduces a new health check feature for Zebra:

- Adds a `gethealthinfo` JSON-RPC method that returns a liveness/readiness status and build metadata.
- Makes the same data available via a simple `GET /health` HTTP request, using `ServerBuilder::health_api`.
- The implementation is guarded by the new `gethealthinfo-rpc` feature flag, so it can be enabled or disabled at build time.
- Includes tests that verify the RPC call and the HTTP endpoint (when the feature is enabled).