### PR TITLE
Try to fix CI failure for v4/v5_with_sapling_spends tests

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -27,14 +27,8 @@ jobs:
       - name: Run tests
         env:
           RUST_BACKTRACE: 1
-        # Skip two tests that intermittently fail on CI (likely a race/ordering issue).
-        # FIXME: investigate and fix the underlying flake; remove these skips once resolved.
-        run: cargo test --locked --verbose -- --skip v4_with_sapling_spends --skip v5_with_sapling_spends
+        run: cargo test --locked --verbose
       # Run the skipped tests separately with constrained parallelism
-      - name: Run Sapling spend tests
-        run: |
-          cargo test -p zebra-consensus v4_with_sapling_spends -- --nocapture
-          cargo test -p zebra-consensus v5_with_sapling_spends -- --nocapture
       - name: Verify working directory is clean
         run: git diff --exit-code
       - name: Run doc check

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -233,27 +233,42 @@ where
         // Check to see if the worker has returned or panicked.
         //
         // Correctness: Registers this task for wakeup when the worker finishes.
-        if let Some(worker_handle) = self
-            .worker_handle
-            .lock()
-            .expect("previous task panicked while holding the worker handle mutex")
-            .as_mut()
+        // FIXME; add a proper comment here
         {
-            match Pin::new(worker_handle).poll(cx) {
-                Poll::Ready(Ok(())) => return Poll::Ready(Err(self.get_worker_error())),
-                Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
-                    tracing::warn!(
-                        "batch task cancelled: {task_cancelled}\n\
-                         Is Zebra shutting down?"
-                    );
-
-                    return Poll::Ready(Err(task_cancelled.into()));
+            // Take the join handle out so we never poll a completed handle again.
+            let mut guard = self
+                .worker_handle
+                .lock()
+                .expect("previous task panicked while holding the worker handle mutex");
+            if let Some(mut handle) = guard.take() {
+                match Pin::new(&mut handle).poll(cx) {
+                    // Worker finished normally: treat as a closed/failed worker.
+                    // Do NOT put the handle back; it's completed and must not be polled again.
+                    Poll::Ready(Ok(())) => {
+                        drop(guard);
+                        return Poll::Ready(Err(self.get_worker_error()));
+                    }
+                    // Worker was cancelled (e.g., runtime shutdown). Also final; don't store it back.
+                    Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
+                        tracing::warn!(
+                            "batch task cancelled: {task_cancelled}\n\
+                             Is Zebra shutting down?"
+                        );
+                        drop(guard);
+                        return Poll::Ready(Err(task_cancelled.into()));
+                    }
+                    // Panic: resume unwind; also final.
+                    Poll::Ready(Err(task_panic)) => {
+                        drop(guard);
+                        std::panic::resume_unwind(task_panic.into_panic());
+                    }
+                    // Still running: put the handle back so other clones can poll it later.
+                    Poll::Pending => {
+                        *guard = Some(handle);
+                    }
                 }
-                Poll::Ready(Err(task_panic)) => {
-                    std::panic::resume_unwind(task_panic.into_panic());
-                }
-                Poll::Pending => {}
             }
+            // guard drops here
         }
 
         // Check if the worker has set an error and closed its channels.

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -166,13 +166,9 @@ where
 
         // Clamp config to sensible values.
         let max_items_in_batch = max(max_items_in_batch, 1);
-        // Floor concurrency at 2 to avoid self-throttling on 1-core CI
-        let max_batches = max(
-            2,
-            max_batches
-                .into()
-                .unwrap_or_else(rayon::current_num_threads),
-        );
+        let max_batches = max_batches
+            .into()
+            .unwrap_or_else(rayon::current_num_threads);
         let max_batches_in_queue = max_batches.clamp(1, QUEUE_BATCH_LIMIT);
 
         // The semaphore bound limits the maximum number of concurrent requests

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -4,7 +4,6 @@ use std::{
     cmp::max,
     fmt,
     future::Future,
-    pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
 };
@@ -230,37 +229,17 @@ where
     type Future = ResponseFuture<T::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // Check to see if the worker has returned or panicked.
-        //
-        // Correctness: Registers this task for wakeup when the worker finishes.
-        let mut worker_handle_guard = self
-            .worker_handle
-            .lock()
-            .expect("previous task panicked while holding the worker handle mutex");
-
-        if let Some(worker_handle) = worker_handle_guard.as_mut() {
-            match Pin::new(worker_handle).poll(cx) {
-                Poll::Ready(Ok(())) => {
-                    // Take the handle so it isn't polled again.
-                    worker_handle_guard.take();
+        // If the worker has *already* finished, treat it as closed; don't poll the handle.
+        {
+            let mut guard = self
+                .worker_handle
+                .lock()
+                .expect("previous task panicked while holding the worker handle mutex");
+            if let Some(handle) = guard.as_ref() {
+                if handle.is_finished() {
+                    guard.take(); // never touch it again
                     return Poll::Ready(Err(self.get_worker_error()));
                 }
-                Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
-                    tracing::warn!(
-                        "batch task cancelled: {task_cancelled}\n\
-                         Is Zebra shutting down?"
-                    );
-
-                    // Take the handle so it isn't polled again.
-                    worker_handle_guard.take();
-                    return Poll::Ready(Err(task_cancelled.into()));
-                }
-                Poll::Ready(Err(task_panic)) => {
-                    // The task panicked, so we must take the handle before resuming the unwind.
-                    worker_handle_guard.take();
-                    std::panic::resume_unwind(task_panic.into_panic());
-                }
-                Poll::Pending => {}
             }
         }
 

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -166,9 +166,13 @@ where
 
         // Clamp config to sensible values.
         let max_items_in_batch = max(max_items_in_batch, 1);
-        let max_batches = max_batches
-            .into()
-            .unwrap_or_else(rayon::current_num_threads);
+        // Floor concurrency at 2 to avoid self-throttling on 1-core CI
+        let max_batches = max(
+            2,
+            max_batches
+                .into()
+                .unwrap_or_else(rayon::current_num_threads),
+        );
         let max_batches_in_queue = max_batches.clamp(1, QUEUE_BATCH_LIMIT);
 
         // The semaphore bound limits the maximum number of concurrent requests

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -233,42 +233,35 @@ where
         // Check to see if the worker has returned or panicked.
         //
         // Correctness: Registers this task for wakeup when the worker finishes.
-        // FIXME; add a proper comment here
-        {
-            // Take the join handle out so we never poll a completed handle again.
-            let mut guard = self
-                .worker_handle
-                .lock()
-                .expect("previous task panicked while holding the worker handle mutex");
-            if let Some(mut handle) = guard.take() {
-                match Pin::new(&mut handle).poll(cx) {
-                    // Worker finished normally: treat as a closed/failed worker.
-                    // Do NOT put the handle back; it's completed and must not be polled again.
-                    Poll::Ready(Ok(())) => {
-                        drop(guard);
-                        return Poll::Ready(Err(self.get_worker_error()));
-                    }
-                    // Worker was cancelled (e.g., runtime shutdown). Also final; don't store it back.
-                    Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
-                        tracing::warn!(
-                            "batch task cancelled: {task_cancelled}\n\
-                             Is Zebra shutting down?"
-                        );
-                        drop(guard);
-                        return Poll::Ready(Err(task_cancelled.into()));
-                    }
-                    // Panic: resume unwind; also final.
-                    Poll::Ready(Err(task_panic)) => {
-                        drop(guard);
-                        std::panic::resume_unwind(task_panic.into_panic());
-                    }
-                    // Still running: put the handle back so other clones can poll it later.
-                    Poll::Pending => {
-                        *guard = Some(handle);
-                    }
+        let mut worker_handle_guard = self
+            .worker_handle
+            .lock()
+            .expect("previous task panicked while holding the worker handle mutex");
+
+        if let Some(worker_handle) = worker_handle_guard.as_mut() {
+            match Pin::new(worker_handle).poll(cx) {
+                Poll::Ready(Ok(())) => {
+                    // Take the handle so it isn't polled again.
+                    worker_handle_guard.take();
+                    return Poll::Ready(Err(self.get_worker_error()));
                 }
+                Poll::Ready(Err(task_cancelled)) if task_cancelled.is_cancelled() => {
+                    tracing::warn!(
+                        "batch task cancelled: {task_cancelled}\n\
+                         Is Zebra shutting down?"
+                    );
+
+                    // Take the handle so it isn't polled again.
+                    worker_handle_guard.take();
+                    return Poll::Ready(Err(task_cancelled.into()));
+                }
+                Poll::Ready(Err(task_panic)) => {
+                    // The task panicked, so we must take the handle before resuming the unwind.
+                    worker_handle_guard.take();
+                    std::panic::resume_unwind(task_panic.into_panic());
+                }
+                Poll::Pending => {}
             }
-            // guard drops here
         }
 
         // Check if the worker has set an error and closed its channels.

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -193,6 +193,18 @@ where
     /// See [`Batch::new()`](crate::Batch::new) for details.
     pub async fn run(mut self) {
         loop {
+            // If all senders are dropped, make sure we flush any pending batch,
+            // even when `recv` is currently gated by `can_spawn_new_batches()`.
+            if self.rx.is_closed() {
+                if self.pending_items > 0 && self.can_spawn_new_batches() {
+                    self.pending_batch_timer = None;
+                    self.flush_service().await;
+                } else if self.pending_items == 0 && self.concurrent_batches.is_empty() {
+                    tracing::trace!("no pending items or running batches, exiting worker task");
+                    return;
+                }
+            }
+
             // Wait on either a new message or the batch timer.
             //
             // If both are ready, end the batch now, because the timer has elapsed.

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -276,8 +276,30 @@ where
                         }
                     }
                     None => {
-                        tracing::trace!("batch channel closed and emptied, exiting worker task");
+                        tracing::trace!(
+                            pending_items = self.pending_items,
+                            running_batches = self.concurrent_batches.len(),
+                            "batch channel closed (no more senders)"
+                        );
 
+                        // If there are pending items, flush them now.
+                        if self.pending_items > 0 {
+                            // Cancel any latency timer; we’ll flush immediately.
+                            self.pending_batch_timer = None;
+                            // Flush and then continue the loop to await completion.
+                            self.flush_service().await;
+                            continue;
+                        }
+
+                        // If there are still running batches, keep waiting for them to finish.
+                        if !self.concurrent_batches.is_empty() {
+                            // Yield so the `concurrent_batches.next()` branch can make progress.
+                            tokio::task::yield_now().await;
+                            continue;
+                        }
+
+                        // No pending items and no running batches: we can exit.
+                        tracing::trace!("no pending items or running batches, exiting worker task");
                         return;
                     }
                 },

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -193,18 +193,6 @@ where
     /// See [`Batch::new()`](crate::Batch::new) for details.
     pub async fn run(mut self) {
         loop {
-            // If all senders are dropped, make sure we flush any pending batch,
-            // even when `recv` is currently gated by `can_spawn_new_batches()`.
-            if self.rx.is_closed() {
-                if self.pending_items > 0 && self.can_spawn_new_batches() {
-                    self.pending_batch_timer = None;
-                    self.flush_service().await;
-                } else if self.pending_items == 0 && self.concurrent_batches.is_empty() {
-                    tracing::trace!("no pending items or running batches, exiting worker task");
-                    return;
-                }
-            }
-
             // Wait on either a new message or the batch timer.
             //
             // If both are ready, end the batch now, because the timer has elapsed.

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -82,11 +82,14 @@ pub static SPEND_VERIFIER: Lazy<
         ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), BoxError>>>,
     >,
 > = Lazy::new(|| {
+    let max_batches = std::cmp::max(2, rayon::current_num_threads());
     Fallback::new(
+        // Avoid self-starvation on tiny CI runners by guaranteeing >= 2 concurrent batches.
+        // Using Some(..) here keeps tower-batch-control tests unchanged elsewhere.
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.spend.vk),
             super::MAX_BATCH_SIZE,
-            None,
+            Some(max_batches),
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -127,11 +127,14 @@ pub static OUTPUT_VERIFIER: Lazy<
         ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), BoxError>>>,
     >,
 > = Lazy::new(|| {
+    let max_batches = std::cmp::max(2, rayon::current_num_threads());
     Fallback::new(
+        // Avoid self-starvation on tiny CI runners by guaranteeing >= 2 concurrent batches.
+        // Using Some(..) here keeps tower-batch-control tests unchanged elsewhere.
         Batch::new(
             Verifier::new(&GROTH16_PARAMETERS.sapling.output.vk),
             super::MAX_BATCH_SIZE,
-            None,
+            Some(max_batches),
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -52,11 +52,14 @@ pub static VERIFIER: Lazy<
         ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), BoxError>>>,
     >,
 > = Lazy::new(|| {
+    let max_batches = std::cmp::max(2, rayon::current_num_threads());
     Fallback::new(
+        // Avoid self-starvation on tiny CI runners by guaranteeing >= 2 concurrent batches.
+        // Using Some(..) here keeps tower-batch-control tests unchanged elsewhere.
         Batch::new(
             Verifier::default(),
             super::MAX_BATCH_SIZE,
-            None,
+            Some(max_batches),
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -52,11 +52,14 @@ pub static VERIFIER: Lazy<
         ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), BoxError>>>,
     >,
 > = Lazy::new(|| {
+    let max_batches = std::cmp::max(2, rayon::current_num_threads());
     Fallback::new(
+        // Avoid self-starvation on tiny CI runners by guaranteeing >= 2 concurrent batches.
+        // Using Some(..) here keeps tower-batch-control tests unchanged elsewhere.
         Batch::new(
             Verifier::default(),
             super::MAX_BATCH_SIZE,
-            None,
+            Some(max_batches),
             super::MAX_BATCH_LATENCY,
         ),
         // We want to fallback to individual verification if batch verification fails,


### PR DESCRIPTION
tower-batch-control: fix double-poll of worker JoinHandle in Batch::poll_ready