### PR TITLE
CI: Fix "No space left on device" errors in ci-basic workflow

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -5,11 +5,7 @@ on: [push]
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
+    runs-on: ubuntu-latest
 
     env:
       # Use system-installed RocksDB library instead of building from scratch
@@ -19,18 +15,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Show system resource summary (before cleanup)
+        run: |
+          df -h
+          free -h
+          lscpu | egrep 'Model name|Socket|Thread|Core|CPU\(s\)'
+
+      - name: Free disk space (safe cleanup for Rust CI)
+        run: |
+          # Remove heavy preinstalled SDKs and toolchains
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true  # preinstalled tool caches
+          df -h
+
       - name: Install dependencies on Ubuntu
         #run: sudo apt-get update && sudo apt-get install -y protobuf-compiler build-essential librocksdb-dev
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --locked
       - name: Verify working directory is clean
         run: git diff --exit-code
       - name: Run doc check
-        run: cargo doc --all-features --document-private-items
+        run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
       - name: Run format check
         run: cargo fmt -- --check
       - name: Run clippy
-        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+        run: cargo clippy --workspace --no-deps --all-features --all-targets --locked -- -D warnings
+      - name: Show system resource summary
+        run: |
+          df -h
+          free -h
+          lscpu | egrep 'Model name|Socket|Thread|Core|CPU\(s\)'


### PR DESCRIPTION
## Problem

The `ci-basic.yml` workflow started failing with "No space left on device" errors across all PRs. This happened even for previously passing PRs that hadn't been modified (#89, for example) when I tried to re-run the CI workflow, for example: https://github.com/QED-it/zebra/actions/runs/17938984393/job/52561489949?pr=89

## Root Cause Investigation

Initially suspected two possible causes:
1. **Dependency version changes** - Missing `--locked` flag in cargo commands could allow dependencies to update and consume more disk space during compilation
2. **GitHub runner disk space reduction** - Changes to `ubuntu-latest` VM resources (reduced total space or increased pre-installed packages)

## Results of the Investigation

1. Adding `--locked` alone didn't resolve the issue, confirming the problem was insufficient available disk space on the GitHub runner. However, I kept the `--locked` flag in this PR as it's the proper way to ensure reproducible builds.
2. I couldn't find information about recent changes to `ubuntu-latest` VM resources on the Internet, and couldn't verify from our previous successful PR runs since we didn't log resource information. I tried cleaning up unused disk space, which resolved the issue.

## Solution

This PR implements disk space optimization for the CI workflow in the existing `ubuntu-latest` instance (continuing to use it), and also adds simple VM resource logging and additional improvements:

1. **Disk Space Cleanup**
   - Remove unused pre-installed Android SDK (`/usr/local/lib/android`)
   - Remove GitHub Actions tool cache (`$AGENT_TOOLSDIRECTORY`)
   - **Result**: Freed ~14 GB of disk space (from 23 GB to 37 GB available)

2. **Resource Monitoring**
   - Added system resource logging (disk, RAM, CPU) before and after cleanup to track space usage

3. **Additional Improvements**
   - Added `--locked` flag to all cargo commands to ensure reproducible builds
   - Added `--no-deps` flag to `cargo doc` and `cargo clippy` to avoid building dependencies unnecessarily
   - Simplified matrix configuration to explicitly use `ubuntu-latest` (removed redundant matrix syntax)