### PR TITLE
Refactor Orchard ShieldedData to support multiple action groups

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["asynchronous", "cryptography::cryptocurrencies", "encoding"]
 [features]
 #default = []
 default = ["tx-v6"]
+#default = ["tx-v6", "zsa-swap"]
 
 # Production features that activate extra functionality
 
@@ -66,6 +67,9 @@ bench = ["zebra-test"]
 tx-v6 = [
     "nonempty"
 ]
+
+# Support for ZSA asset swaps
+zsa-swap = []
 
 [dependencies]
 

--- a/zebra-chain/src/orchard.rs
+++ b/zebra-chain/src/orchard.rs
@@ -23,7 +23,7 @@ pub use address::Address;
 pub use commitment::{CommitmentRandomness, NoteCommitment, ValueCommitment};
 pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
-pub use shielded_data::{AuthorizedAction, Flags, ShieldedData};
+pub use shielded_data::{ActionGroup, AuthorizedAction, Flags, ShieldedData};
 pub use shielded_data_flavor::{OrchardVanilla, ShieldedDataFlavor};
 
 pub(crate) use shielded_data::ActionCommon;

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -47,7 +47,7 @@ pub struct ActionGroup<FL: ShieldedDataFlavor> {
     #[cfg(feature = "tx-v6")]
     /// Assets intended for burning
     /// Denoted as `vAssetBurn` in the spec (ZIP 230).
-    pub(crate) burn: FL::BurnType,
+    pub burn: FL::BurnType,
 }
 
 impl<FL: ShieldedDataFlavor> ActionGroup<FL> {

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -198,7 +198,7 @@ impl<FL: ShieldedDataFlavor> ShieldedData<FL> {
     pub fn shared_anchors(&self) -> impl Iterator<Item = tree::Root> + '_ {
         self.action_groups
             .iter()
-            .map(|action_group| action_group.shared_anchor.clone())
+            .map(|action_group| action_group.shared_anchor)
     }
 
     /// Iterate over the [`AuthorizedAction`]s in this

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -30,12 +30,18 @@ use super::{OrchardVanilla, ShieldedDataFlavor};
 
 // FIXME: wrap all ActionGroup usages with tx_v6 feature flag?
 /// Action Group description.
-#[cfg(feature = "tx_v6")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(bound(
-    serialize = "Flavor::EncryptedNote: serde::Serialize, Flavor::BurnType: serde::Serialize",
-    deserialize = "Flavor::BurnType: serde::Deserialize<'de>"
-))]
+#[cfg_attr(
+    not(feature = "tx_v6"),
+    serde(bound(serialize = "Flavor::EncryptedNote: serde::Serialize"))
+)]
+#[cfg_attr(
+    feature = "tx_v6",
+    serde(bound(
+        serialize = "Flavor::EncryptedNote: serde::Serialize, Flavor::BurnType: serde::Serialize",
+        deserialize = "Flavor::BurnType: serde::Deserialize<'de>"
+    ))
+)]
 pub struct ActionGroup<Flavor: ShieldedDataFlavor> {
     /// The orchard flags for this transaction.
     /// Denoted as `flagsOrchard` in the spec.
@@ -72,10 +78,17 @@ impl<Flavor: ShieldedDataFlavor> ActionGroup<Flavor> {
 
 /// A bundle of [`Action`] descriptions and signature data.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(bound(
-    serialize = "Flavor::EncryptedNote: serde::Serialize, Flavor::BurnType: serde::Serialize",
-    deserialize = "Flavor::BurnType: serde::Deserialize<'de>"
-))]
+#[cfg_attr(
+    not(feature = "tx_v6"),
+    serde(bound(serialize = "Flavor::EncryptedNote: serde::Serialize"))
+)]
+#[cfg_attr(
+    feature = "tx_v6",
+    serde(bound(
+        serialize = "Flavor::EncryptedNote: serde::Serialize, Flavor::BurnType: serde::Serialize",
+        deserialize = "Flavor::BurnType: serde::Deserialize<'de>"
+    ))
+)]
 pub struct ShieldedData<Flavor: ShieldedDataFlavor> {
     /// Action Group descriptions.
     /// Denoted as `vActionGroupsOrchard` in the spec (ZIP 230).

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -22,8 +22,8 @@ use crate::{
 
 use super::{OrchardVanilla, ShieldedDataFlavor};
 
-// FIXME: wrap all ActionGroup usages withj tx-v6 feature flag?
-/// FIXME: add doc
+// FIXME: wrap all ActionGroup usages with tx-v6 feature flag?
+/// Action Group description.
 #[cfg(feature = "tx-v6")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(bound(
@@ -65,7 +65,8 @@ impl<FL: ShieldedDataFlavor> ActionGroup<FL> {
     deserialize = "FL::BurnType: serde::Deserialize<'de>"
 ))]
 pub struct ShieldedData<FL: ShieldedDataFlavor> {
-    /// FIXME: add doc
+    /// Action Group descriptions.
+    /// Denoted as `vActionGroupsOrchard` in the spec (ZIP 230).
     pub action_groups: AtLeastOne<ActionGroup<FL>>,
     /// Denoted as `valueBalanceOrchard` in the spec.
     pub value_balance: Amount,

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -91,17 +91,18 @@ impl<Flavor: ShieldedDataFlavor> fmt::Display for ActionGroup<Flavor> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fmter = f.debug_struct("orchard::ActionGroup");
 
-        // FIXME: reorder fields here according the struct/spec?
-
         fmter.field("actions", &self.actions.len());
         fmter.field("flags", &self.flags);
+
+        #[cfg(feature = "tx_v6")]
+        fmter.field("expiry_height", &self.expiry_height);
+
+        #[cfg(feature = "tx_v6")]
+        fmter.field("burn", &self.burn.as_ref().len());
 
         fmter.field("proof_len", &self.proof.zcash_serialized_size());
 
         fmter.field("shared_anchor", &self.shared_anchor);
-
-        #[cfg(feature = "tx_v6")]
-        fmter.field("burn", &self.burn.as_ref().len());
 
         fmter.finish()
     }

--- a/zebra-chain/src/orchard/shielded_data_flavor.rs
+++ b/zebra-chain/src/orchard/shielded_data_flavor.rs
@@ -57,6 +57,8 @@ pub trait ShieldedDataFlavor: OrchardFlavor {
     type BurnType: Clone
         + Debug
         + Default
+        + PartialEq
+        + Eq
         + ZcashDeserialize
         + ZcashSerialize
         + Into<ValueCommitment>

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -70,8 +70,8 @@ pub fn decrypts_successfully(transaction: &Transaction, network: &Network, heigh
 }
 
 /// Checks if all actions in an Orchard bundle decrypt successfully.
-fn orchard_bundle_decrypts_successfully<A: Authorization, V, D: OrchardPrimitives>(
-    bundle: &Bundle<A, V, D>,
+fn orchard_bundle_decrypts_successfully<A: Authorization, V, P: OrchardPrimitives>(
+    bundle: &Bundle<A, V, P>,
 ) -> bool {
     bundle.actions().iter().all(|act| {
         zcash_note_encryption::try_output_recovery_with_ovk(

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -356,7 +356,7 @@ impl ZcashSerialize for orchard::ShieldedData<OrchardVanilla> {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         assert!(
             self.action_groups.len() == 1,
-            "only one action group is supported for transaction V5"
+            "V6 transaction must contain exactly one action group"
         );
 
         let action_group = self.action_groups.first();
@@ -402,52 +402,60 @@ impl ZcashSerialize for orchard::ShieldedData<OrchardVanilla> {
 #[allow(clippy::unwrap_in_result)]
 impl ZcashSerialize for orchard::ShieldedData<OrchardZSA> {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        // FIXME: Implement serialization of multiple action groups (under a feature flag)
-
+        #[cfg(not(feature = "zsa-swap"))]
         assert!(
             self.action_groups.len() == 1,
             "V6 transaction must contain exactly one action group"
         );
 
-        let action_group = self.action_groups.first();
+        // FIXME: consider using use zcash_serialize_external_count for or Vec::zcash_serialize
+        for action_group in self.action_groups.iter() {
+            // Denoted as `nActionGroupsOrchard` in the spec  (ZIP 230) (must be one for V6/NU7).
+            CompactSizeMessage::try_from(self.action_groups.len())
+                .expect("nActionGroupsOrchard should convert to CompactSizeMessage")
+                .zcash_serialize(&mut writer)?;
 
-        // Denoted as `nActionGroupsOrchard` in the spec  (ZIP 230) (must be one for V6/NU7).
-        CompactSizeMessage::try_from(self.action_groups.len())
-            .expect("nActionGroupsOrchard should convert to CompactSizeMessage")
-            .zcash_serialize(&mut writer)?;
+            // Split the AuthorizedAction
+            let (actions, sigs): (Vec<orchard::Action<OrchardZSA>>, Vec<Signature<SpendAuth>>) =
+                action_group
+                    .actions
+                    .iter()
+                    .cloned()
+                    .map(orchard::AuthorizedAction::into_parts)
+                    .unzip();
 
-        // Split the AuthorizedAction
-        let (actions, sigs): (Vec<orchard::Action<OrchardZSA>>, Vec<Signature<SpendAuth>>) =
-            action_group
-                .actions
-                .iter()
-                .cloned()
-                .map(orchard::AuthorizedAction::into_parts)
-                .unzip();
+            // Denoted as `nActionsOrchard` and `vActionsOrchard` in the spec.
+            actions.zcash_serialize(&mut writer)?;
 
-        // Denoted as `nActionsOrchard` and `vActionsOrchard` in the spec.
-        actions.zcash_serialize(&mut writer)?;
+            // Denoted as `flagsOrchard` in the spec.
+            action_group.flags.zcash_serialize(&mut writer)?;
 
-        // Denoted as `flagsOrchard` in the spec.
-        action_group.flags.zcash_serialize(&mut writer)?;
+            // Denoted as `anchorOrchard` in the spec.
+            action_group.shared_anchor.zcash_serialize(&mut writer)?;
 
-        // Denoted as `anchorOrchard` in the spec.
-        action_group.shared_anchor.zcash_serialize(&mut writer)?;
+            // Denoted as `sizeProofsOrchard` and `proofsOrchard` in the spec.
+            action_group.proof.zcash_serialize(&mut writer)?;
 
-        // Denoted as `sizeProofsOrchard` and `proofsOrchard` in the spec.
-        action_group.proof.zcash_serialize(&mut writer)?;
+            // Denoted as `nAGExpiryHeight` in the spec  (ZIP 230) (must be zero for V6/NU7).
+            writer.write_u32::<LittleEndian>(0)?;
 
-        // Denoted as `nAGExpiryHeight` in the spec  (ZIP 230) (must be zero for V6/NU7).
-        writer.write_u32::<LittleEndian>(0)?;
+            // Denoted as `vAssetBurn` in the spec (ZIP 230).
+            #[cfg(feature = "zsa-swap")]
+            action_group.burn.zcash_serialize(&mut writer)?;
 
-        // Denoted as `vSpendAuthSigsOrchard` in the spec.
-        zcash_serialize_external_count(&sigs, &mut writer)?;
+            // Denoted as `vSpendAuthSigsOrchard` in the spec.
+            zcash_serialize_external_count(&sigs, &mut writer)?;
+        }
 
         // Denoted as `valueBalanceOrchard` in the spec.
         self.value_balance.zcash_serialize(&mut writer)?;
 
         // Denoted as `vAssetBurn` in the spec (ZIP 230).
-        action_group.burn.zcash_serialize(&mut writer)?;
+        #[cfg(not(feature = "zsa-swap"))]
+        self.action_groups
+            .first()
+            .burn
+            .zcash_serialize(&mut writer)?;
 
         // Denoted as `bindingSigOrchard` in the spec.
         self.binding_sig.zcash_serialize(&mut writer)?;
@@ -545,82 +553,103 @@ impl ZcashDeserialize for Option<orchard::ShieldedData<OrchardZSA>> {
         let n_action_groups: usize = (&mut reader)
             .zcash_deserialize_into::<CompactSizeMessage>()?
             .into();
+
         if n_action_groups == 0 {
             return Ok(None);
-        } else if n_action_groups != 1 {
+        }
+
+        #[cfg(not(feature = "zsa-swap"))]
+        if n_action_groups != 1 {
             return Err(SerializationError::Parse(
                 "V6 transaction must contain exactly one action group",
             ));
         }
 
-        // Denoted as `nActionsOrchard` and `vActionsOrchard` in the spec.
-        let actions: Vec<orchard::Action<OrchardZSA>> = (&mut reader).zcash_deserialize_into()?;
+        let mut action_groups = Vec::with_capacity(n_action_groups);
 
-        // # Consensus
-        //
-        // > Elements of an Action description MUST be canonical encodings of the types given above.
-        //
-        // https://zips.z.cash/protocol/protocol.pdf#actiondesc
-        //
-        // Some Action elements are validated in this function; they are described below.
+        // FIXME: use zcash_deserialize_external_count for or Vec::zcash_deserialize for allocation safety
+        for _ in 0..n_action_groups {
+            // Denoted as `nActionsOrchard` and `vActionsOrchard` in the spec.
+            let actions: Vec<orchard::Action<OrchardZSA>> =
+                (&mut reader).zcash_deserialize_into()?;
 
-        // Denoted as `flagsOrchard` in the spec.
-        // Consensus: type of each flag is 𝔹, i.e. a bit. This is enforced implicitly
-        // in [`Flags::zcash_deserialized`].
-        let flags: orchard::Flags = (&mut reader).zcash_deserialize_into()?;
+            // # Consensus
+            //
+            // > Elements of an Action description MUST be canonical encodings of the types given above.
+            //
+            // https://zips.z.cash/protocol/protocol.pdf#actiondesc
+            //
+            // Some Action elements are validated in this function; they are described below.
 
-        // Denoted as `anchorOrchard` in the spec.
-        // Consensus: type is `{0 .. 𝑞_ℙ − 1}`. See [`orchard::tree::Root::zcash_deserialize`].
-        let shared_anchor: orchard::tree::Root = (&mut reader).zcash_deserialize_into()?;
+            // Denoted as `flagsOrchard` in the spec.
+            // Consensus: type of each flag is 𝔹, i.e. a bit. This is enforced implicitly
+            // in [`Flags::zcash_deserialized`].
+            let flags: orchard::Flags = (&mut reader).zcash_deserialize_into()?;
 
-        // Denoted as `sizeProofsOrchard` and `proofsOrchard` in the spec.
-        // Consensus: type is `ZKAction.Proof`, i.e. a byte sequence.
-        // https://zips.z.cash/protocol/protocol.pdf#halo2encoding
-        let proof: Halo2Proof = (&mut reader).zcash_deserialize_into()?;
+            // Denoted as `anchorOrchard` in the spec.
+            // Consensus: type is `{0 .. 𝑞_ℙ − 1}`. See [`orchard::tree::Root::zcash_deserialize`].
+            let shared_anchor: orchard::tree::Root = (&mut reader).zcash_deserialize_into()?;
 
-        // Denoted as `nAGExpiryHeight` in the spec  (ZIP 230) (must be zero for V6/NU7).
-        let n_ag_expiry_height = reader.read_u32::<LittleEndian>()?;
-        if n_ag_expiry_height != 0 {
-            return Err(SerializationError::Parse("nAGExpiryHeight for V6/NU7"));
-        }
+            // Denoted as `sizeProofsOrchard` and `proofsOrchard` in the spec.
+            // Consensus: type is `ZKAction.Proof`, i.e. a byte sequence.
+            // https://zips.z.cash/protocol/protocol.pdf#halo2encoding
+            let proof: Halo2Proof = (&mut reader).zcash_deserialize_into()?;
 
-        // Denoted as `vSpendAuthSigsOrchard` in the spec.
-        // Consensus: this validates the `spendAuthSig` elements, whose type is
-        // SpendAuthSig^{Orchard}.Signature, i.e.
-        // B^Y^{[ceiling(ℓ_G/8) + ceiling(bitlength(𝑟_G)/8)]} i.e. 64 bytes
-        // See [`Signature::zcash_deserialize`].
-        let sigs: Vec<Signature<SpendAuth>> =
-            zcash_deserialize_external_count(actions.len(), &mut reader)?;
+            // Denoted as `nAGExpiryHeight` in the spec  (ZIP 230) (must be zero for V6/NU7).
+            let n_ag_expiry_height = reader.read_u32::<LittleEndian>()?;
+            if n_ag_expiry_height != 0 {
+                return Err(SerializationError::Parse("nAGExpiryHeight for V6/NU7"));
+            }
 
-        // Denoted as `valueBalanceOrchard` in the spec.
-        let value_balance: amount::Amount = (&mut reader).zcash_deserialize_into()?;
+            // Denoted as `vAssetBurn` in the spec  (ZIP 230).
+            #[cfg(feature = "zsa-swap")]
+            let burn = (&mut reader).zcash_deserialize_into()?;
+            #[cfg(not(feature = "zsa-swap"))]
+            let burn = Default::default();
 
-        // Denoted as `vAssetBurn` in the spec  (ZIP 230).
-        let burn = (&mut reader).zcash_deserialize_into()?;
+            // Denoted as `vSpendAuthSigsOrchard` in the spec.
+            // Consensus: this validates the `spendAuthSig` elements, whose type is
+            // SpendAuthSig^{Orchard}.Signature, i.e.
+            // B^Y^{[ceiling(ℓ_G/8) + ceiling(bitlength(𝑟_G)/8)]} i.e. 64 bytes
+            // See [`Signature::zcash_deserialize`].
+            let sigs: Vec<Signature<SpendAuth>> =
+                zcash_deserialize_external_count(actions.len(), &mut reader)?;
 
-        // Denoted as `bindingSigOrchard` in the spec.
-        let binding_sig: Signature<Binding> = (&mut reader).zcash_deserialize_into()?;
+            // Create the AuthorizedAction from deserialized parts
+            let authorized_actions: Vec<orchard::AuthorizedAction<OrchardZSA>> = actions
+                .into_iter()
+                .zip(sigs)
+                .map(|(action, spend_auth_sig)| {
+                    orchard::AuthorizedAction::from_parts(action, spend_auth_sig)
+                })
+                .collect();
 
-        // Create the AuthorizedAction from deserialized parts
-        let authorized_actions: Vec<orchard::AuthorizedAction<OrchardZSA>> = actions
-            .into_iter()
-            .zip(sigs)
-            .map(|(action, spend_auth_sig)| {
-                orchard::AuthorizedAction::from_parts(action, spend_auth_sig)
-            })
-            .collect();
+            let actions: AtLeastOne<orchard::AuthorizedAction<OrchardZSA>> =
+                authorized_actions.try_into()?;
 
-        let actions: AtLeastOne<orchard::AuthorizedAction<OrchardZSA>> =
-            authorized_actions.try_into()?;
-
-        Ok(Some(orchard::ShieldedData::<OrchardZSA> {
-            action_groups: AtLeastOne::from_one(ActionGroup {
+            action_groups.push(ActionGroup {
                 flags,
                 shared_anchor,
                 proof,
                 actions,
                 burn,
-            }),
+            })
+        }
+
+        // Denoted as `valueBalanceOrchard` in the spec.
+        let value_balance: amount::Amount = (&mut reader).zcash_deserialize_into()?;
+
+        // Denoted as `vAssetBurn` in the spec  (ZIP 230).
+        #[cfg(not(feature = "zsa-swap"))]
+        {
+            action_groups[0].burn = (&mut reader).zcash_deserialize_into()?;
+        }
+
+        // Denoted as `bindingSigOrchard` in the spec.
+        let binding_sig: Signature<Binding> = (&mut reader).zcash_deserialize_into()?;
+
+        Ok(Some(orchard::ShieldedData::<OrchardZSA> {
+            action_groups: action_groups.try_into()?,
             value_balance,
             binding_sig,
         }))

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -541,7 +541,7 @@ impl ZcashDeserialize for Option<orchard::ShieldedData<OrchardZSA>> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
         // FIXME: Implement deserialization of multiple action groups (under a feature flag)
 
-        // Denoted as `nActionGroupsOrchard` in the spec  (ZIP 230) (must be one for V6/NU7).
+        // Denoted as `nActionGroupsOrchard` in the spec (ZIP 230) (must be one for V6/NU7).
         let n_action_groups: usize = (&mut reader)
             .zcash_deserialize_into::<CompactSizeMessage>()?
             .into();

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["asynchronous", "cryptography::cryptocurrencies"]
 [features]
 #default = []
 default = ["tx-v6"]
+#default = ["tx-v6", "zsa-swap"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
@@ -39,6 +40,12 @@ proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl", "ze
 tx-v6 = [
     "zebra-state/tx-v6",
     "zebra-chain/tx-v6"
+]
+
+# Support for ZSA asset swaps
+zsa-swap = [
+    "zebra-state/zsa-swap",
+    "zebra-chain/zsa-swap"
 ]
 
 [dependencies]

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -148,7 +148,7 @@ impl<V: OrchardVerifier> From<&ActionGroup<V>> for Item {
         let anchor = tree::Anchor::from_bytes(action_group.shared_anchor.into()).unwrap();
 
         let flags = orchard::bundle::Flags::from_byte(action_group.flags.bits())
-            .expect("failed to convert flags: shielded_data.flags contains unexpected bits that are not valid in orchard::bundle::Flags");
+            .expect("failed to convert flags: action_group.flags contains unexpected bits that are not valid in orchard::bundle::Flags");
 
         let instances = action_group
             .actions()

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -19,7 +19,7 @@ use tower::{util::ServiceFn, Service};
 use tower_batch_control::{Batch, BatchControl};
 use tower_fallback::Fallback;
 
-use zebra_chain::orchard::{OrchardVanilla, OrchardZSA, ShieldedData, ShieldedDataFlavor};
+use zebra_chain::orchard::{ActionGroup, OrchardVanilla, OrchardZSA, ShieldedDataFlavor};
 
 use crate::BoxError;
 
@@ -136,16 +136,16 @@ impl BatchVerifier {
 
 // === END TEMPORARY BATCH HALO2 SUBSTITUTE ===
 
-impl<V: OrchardVerifier> From<&ShieldedData<V>> for Item {
-    fn from(shielded_data: &ShieldedData<V>) -> Item {
+impl<V: OrchardVerifier> From<&ActionGroup<V>> for Item {
+    fn from(action_group: &ActionGroup<V>) -> Item {
         use orchard::{circuit, note, primitives::redpallas, tree, value};
 
-        let anchor = tree::Anchor::from_bytes(shielded_data.shared_anchor.into()).unwrap();
+        let anchor = tree::Anchor::from_bytes(action_group.shared_anchor.into()).unwrap();
 
-        let flags = orchard::bundle::Flags::from_byte(shielded_data.flags.bits())
+        let flags = orchard::bundle::Flags::from_byte(action_group.flags.bits())
             .expect("type should not have unexpected bits");
 
-        let instances = shielded_data
+        let instances = action_group
             .actions()
             .map(|action| {
                 circuit::Instance::from_parts(
@@ -164,7 +164,7 @@ impl<V: OrchardVerifier> From<&ShieldedData<V>> for Item {
 
         Item {
             instances,
-            proof: orchard::circuit::Proof::new(shielded_data.proof.0.clone()),
+            proof: orchard::circuit::Proof::new(action_group.proof.0.clone()),
         }
     }
 }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -1136,6 +1136,7 @@ where
         let mut async_checks = AsyncChecks::new();
 
         if let Some(orchard_shielded_data) = orchard_shielded_data {
+            // FIXME: update the comment to describe action groups
             // # Consensus
             //
             // > The proof 𝜋 MUST be valid given a primary input (cv, rt^{Orchard},
@@ -1147,13 +1148,15 @@ where
             // aggregated Halo2 proof per transaction, even with multiple
             // Actions in one transaction. So we queue it for verification
             // only once instead of queuing it up for every Action description.
-            async_checks.push(
-                V::get_verifier()
-                    .clone()
-                    .oneshot(primitives::halo2::Item::from(orchard_shielded_data)),
-            );
+            for action_group in orchard_shielded_data.action_groups.iter() {
+                async_checks.push(
+                    V::get_verifier()
+                        .clone()
+                        .oneshot(primitives::halo2::Item::from(action_group)),
+                )
+            }
 
-            for authorized_action in orchard_shielded_data.actions.iter().cloned() {
+            for authorized_action in orchard_shielded_data.authorized_actions().cloned() {
                 let (action, spend_auth_sig) = authorized_action.into_parts();
 
                 // # Consensus

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -172,7 +172,8 @@ pub fn coinbase_tx_no_prevout_joinsplit_spend(tx: &Transaction) -> Result<(), Tr
             return Err(TransactionError::CoinbaseHasSpend);
         }
 
-        if let Some(orchard_flags) = tx.orchard_flags() {
+        // FIXME: is it correct to use orchard_flags_union here?
+        if let Some(orchard_flags) = tx.orchard_flags_union() {
             if orchard_flags.contains(Flags::ENABLE_SPENDS) {
                 return Err(TransactionError::CoinbaseHasEnableSpendsOrchard);
             }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["asynchronous", "caching", "cryptography::cryptocurrencies"]
 [features]
 #default = []
 default = ["tx-v6"]
+#default = ["tx-v6", "zsa-swap"]
 
 # Production features that activate extra dependencies, or extra features in dependencies
 
@@ -50,6 +51,11 @@ elasticsearch = [
 # Support for transaction version 6
 tx-v6 = [
     "zebra-chain/tx-v6"
+]
+
+# Support for ZSA asset swaps
+zsa-swap = [
+    "zebra-chain/zsa-swap"
 ]
 
 [dependencies]

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -88,9 +88,12 @@ fn sapling_orchard_anchors_refer_to_final_treestates(
     // > earlier block’s final Orchard treestate.
     //
     // <https://zips.z.cash/protocol/protocol.pdf#actions>
-    if let Some(shared_anchor) = transaction.orchard_shared_anchor() {
+    for (shared_anchor_index_in_tx, shared_anchor) in
+        transaction.orchard_shared_anchors().enumerate()
+    {
         tracing::debug!(
             ?shared_anchor,
+            ?shared_anchor_index_in_tx,
             ?tx_index_in_block,
             ?height,
             "observed orchard anchor",
@@ -111,6 +114,7 @@ fn sapling_orchard_anchors_refer_to_final_treestates(
 
         tracing::debug!(
             ?shared_anchor,
+            ?shared_anchor_index_in_tx,
             ?tx_index_in_block,
             ?height,
             "validated orchard anchor",

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -1134,9 +1134,11 @@ fn transaction_v5_with_orchard_shielded_data(
 
     if let Some(ref mut orchard_shielded_data) = orchard_shielded_data {
         // make sure there are no other nullifiers, by replacing all the authorized_actions
-        orchard_shielded_data.actions = authorized_actions.try_into().expect(
-            "unexpected invalid orchard::ShieldedData: must have at least one AuthorizedAction",
-        );
+        // FIXME: works for V5 or V6 with a single action group only
+        orchard_shielded_data.action_groups.first_mut().actions =
+            authorized_actions.try_into().expect(
+                "unexpected invalid orchard::ShieldedData: must have at least one AuthorizedAction",
+            );
 
         // set value balance to 0 to pass the chain value pool checks
         let zero_amount = 0.try_into().expect("unexpected invalid zero amount");

--- a/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
@@ -66,7 +66,7 @@ impl ZebraDb {
             }
 
             // Orchard
-            if let Some(shared_anchor) = transaction.orchard_shared_anchor() {
+            for shared_anchor in transaction.orchard_shared_anchors() {
                 batch.zs_insert(&orchard_anchors, shared_anchor, ());
             }
         }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -54,6 +54,7 @@ features = [
 # In release builds, don't compile debug logging code, to improve performance.
 #default = ["release_max_level_info", "progress-bar", "getblocktemplate-rpcs"]
 default = ["release_max_level_info", "progress-bar", "getblocktemplate-rpcs", "tx-v6"]
+#default = ["release_max_level_info", "progress-bar", "getblocktemplate-rpcs", "tx-v6", "zsa-swap"]
 
 # Default features for official ZF binary release builds
 default-release-binaries = ["default", "sentry"]
@@ -162,6 +163,13 @@ tx-v6 = [
     "zebra-consensus/tx-v6",
     "zebra-state/tx-v6",
     "zebra-chain/tx-v6"
+]
+
+# Support for ZSA asset swaps
+zsa-swap = [
+    "zebra-consensus/zsa-swap",
+    "zebra-state/zsa-swap",
+    "zebra-chain/zsa-swap"
 ]
 
 [dependencies]

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -747,7 +747,10 @@ impl SpendConflictTestInput {
         conflicts: &HashSet<orchard::Nullifier>,
     ) {
         if let Some(shielded_data) = maybe_shielded_data.take() {
+            // FIXME: works for V5 or V6 with a single action group only
             let updated_actions: Vec<_> = shielded_data
+                .action_groups
+                .first()
                 .actions
                 .into_vec()
                 .into_iter()
@@ -955,8 +958,14 @@ impl OrchardSpendConflict {
         orchard_shielded_data: &mut Option<orchard::ShieldedData<orchard::OrchardVanilla>>,
     ) {
         if let Some(shielded_data) = orchard_shielded_data.as_mut() {
-            shielded_data.actions.first_mut().action.nullifier =
-                self.new_shielded_data.actions.first().action.nullifier;
+            // FIXME: works for V5 or V6 with a single action group only
+            shielded_data
+                .action_groups
+                .first_mut()
+                .actions
+                .first_mut()
+                .action
+                .nullifier = self.new_shielded_data.actions.first().action.nullifier;
         } else {
             *orchard_shielded_data = Some(self.new_shielded_data.0);
         }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -961,7 +961,12 @@ impl OrchardSpendConflict {
                 .actions
                 .first_mut()
                 .action
-                .nullifier = self.new_shielded_data.actions().next().action.nullifier;
+                .nullifier = self
+                .new_shielded_data
+                .actions()
+                .next()
+                .expect("at least one action")
+                .nullifier;
         } else {
             *orchard_shielded_data = Some(self.new_shielded_data.0);
         }


### PR DESCRIPTION
Switch Orchard `ShieldedData` to the` ZIP 230` action-group layout so V6 transactions can carry multiple Orchard action groups instead of a single flat section.

Flags, shared anchor, burn data, proof, actions, and the per–action-group expiry height now live inside an `ActionGroup` structure. `ShieldedData` now holds a non-empty list of action groups, plus the shared value balance and binding signature. Transaction serialization / deserialization and Orchard-related callers are updated to use this layout.

By default, serialization asserts that there is exactly one action group, so behaviour for a single action group remains equivalent to the previous layout. Real multi–action-group support in the serialization is gated behind the new `zsa-swap` feature flag. This PR is mainly structural, to match the V6 format and prepare for swaps and other multiple–action-group use cases.