### PR TITLE
Add print step in push-ecr of zebra

### DIFF
--- a/.github/workflows/push-ecr.yaml
+++ b/.github/workflows/push-ecr.yaml
@@ -61,7 +61,7 @@ jobs:
           
           # Set the input IMAGE_TAG_VERSION
           echo "IMAGE_TAG_VERSION=${{ github.event.inputs.image_tag_version }}" >> $GITHUB_ENV
-                echo "  User-provided IMAGE_TAG_VERSION: ${{ github.event.inputs.image_tag_version }}"
+          echo "  User-provided IMAGE_TAG_VERSION: ${{ github.event.inputs.image_tag_version }}"
       
       - name: Print run information
         run: |

--- a/.github/workflows/push-ecr.yaml
+++ b/.github/workflows/push-ecr.yaml
@@ -61,7 +61,15 @@ jobs:
           
           # Set the input IMAGE_TAG_VERSION
           echo "IMAGE_TAG_VERSION=${{ github.event.inputs.image_tag_version }}" >> $GITHUB_ENV
-          echo "  User-provided IMAGE_TAG_VERSION: ${{ github.event.inputs.image_tag_version }}"
+                echo "  User-provided IMAGE_TAG_VERSION: ${{ github.event.inputs.image_tag_version }}"
+      
+      - name: Print run information
+        run: |
+          echo "Branch/Ref: ${{ github.ref_name }}"
+          echo "Full Ref: ${{ github.ref }}"
+          echo "Event: ${{ github.event_name }}"
+          echo "Inputs:"
+          echo "  image_tag_version: ${{ github.event.inputs.image_tag_version || '(not set)' }}"
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
## Motivation

We want to know post running the CD step what exact version was deployed, in a single and centralized step.

### Specifications & References

The PR adds an information print step in the CD (push to ecr) pipeline of ECS.

## Solution

Add a print step.

### Tests

I ran it to try.

### Follow-up Work

Might need to add a similar test to tx-tool.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary. [Not needed]
- [x] The solution is tested.
- [x] The documentation is up to date.
- [ ] The PR has a priority label. [Not needed]

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

