### PR TITLE
Create stop-ecs workflow

### DIFF
--- a/.github/workflows/stop-ecs.yaml
+++ b/.github/workflows/stop-ecs.yaml
@@ -1,0 +1,72 @@
+name: Stop All ECS Tasks
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "yes" to confirm stopping all tasks'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
+  ECS_SERVICE: ${{ vars.ECS_SERVICE || 'dev-zebra' }}
+  ECS_CLUSTER: ${{ vars.ECS_CLUSTER || 'dev-zebra-cluster' }}
+
+jobs:
+  stop-tasks:
+    name: Stop All ECS Tasks
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Validate confirmation
+        if: ${{ github.event.inputs.confirm != 'yes' }}
+        run: |
+          echo "Confirmation not provided. Please type 'yes' to confirm."
+          exit 1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Stop all running tasks
+        run: |
+          echo "Fetching running tasks for service: $ECS_SERVICE in cluster: $ECS_CLUSTER"
+          
+          TASK_ARNS=$(aws ecs list-tasks \
+            --cluster $ECS_CLUSTER \
+            --service-name $ECS_SERVICE \
+            --query 'taskArns[]' \
+            --output text)
+          
+          if [ -z "$TASK_ARNS" ]; then
+            echo "No running tasks found."
+            exit 0
+          fi
+          
+          echo "Found tasks: $TASK_ARNS"
+          
+          for TASK_ARN in $TASK_ARNS; do
+            echo "Stopping task: $TASK_ARN"
+            aws ecs stop-task \
+              --cluster $ECS_CLUSTER \
+              --task $TASK_ARN \
+              --reason "Manually stopped via GitHub Actions"
+          done
+          
+          echo "All tasks have been stopped."
+
+      - name: Verify tasks stopped
+        run: |
+          echo "Waiting 30 seconds for tasks to stop..."
+          sleep 30
+          
+          echo "Current task status:"
+          aws ecs describe-services \
+            --cluster $ECS_CLUSTER \
+            --services $ECS_SERVICE \
+            --query 'services[0].{RunningCount:runningCount,PendingCount:pendingCount,DesiredCount:desiredCount}' \
+            --output table

--- a/.github/workflows/stop-ecs.yaml
+++ b/.github/workflows/stop-ecs.yaml
@@ -2,11 +2,6 @@ name: Stop All ECS Tasks
 
 on:
   workflow_dispatch:
-    inputs:
-      confirm:
-        description: 'Type "yes" to confirm stopping all tasks'
-        required: true
-        type: string
 
 env:
   AWS_REGION: ${{ vars.AWS_REGION || 'eu-central-1' }}
@@ -19,12 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - name: Validate confirmation
-        if: ${{ github.event.inputs.confirm != 'yes' }}
-        run: |
-          echo "Confirmation not provided. Please type 'yes' to confirm."
-          exit 1
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## Motivation
The Zebra running in ECS is not configured to save the state in the file system (under /persistence) but in memory (RAM) - meaning that upon a task restart the state will be removed and the running time for the tx-tool will be improved (nullified).
This PR adds a simple Github Actions Workflow to kill all the currently running ECS tasks (ECS will spawn automatically new tasks)

Minimal IAM permissions to run this task:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "ListTasksInSpecificCluster",
      "Effect": "Allow",
      "Action": "ecs:ListTasks",
      "Resource": "*",
      "Condition": {
        "StringEquals": {
          "ecs:cluster": "arn:aws:ecs:eu-central-1:ACCOUNT_ID:cluster/dev-zebra-cluster"
        }
      }
    },
    {
      "Sid": "StopTasksInSpecificCluster",
      "Effect": "Allow",
      "Action": "ecs:StopTask",
      "Resource": "arn:aws:ecs:eu-central-1:ACCOUNT_ID:task/dev-zebra-cluster/*",
      "Condition": {
        "StringEquals": {
          "ecs:cluster": "arn:aws:ecs:eu-central-1:ACCOUNT_ID:cluster/dev-zebra-cluster"
        }
      }
    },
    {
      "Sid": "DescribeSpecificService",
      "Effect": "Allow",
      "Action": "ecs:DescribeServices",
      "Resource": "arn:aws:ecs:eu-central-1:ACCOUNT_ID:service/dev-zebra-cluster/dev-zebra"
    }
  ]
}
```