### PR TITLE
Update Orchard and librustzcash refs for PR471 review sync

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -42,7 +42,20 @@ jobs:
       - name: Run format check
         run: cargo fmt -- --check
       - name: Run clippy
-        run: cargo clippy --workspace --no-deps --all-features --all-targets --locked -- -D warnings
+        run: |
+          # Keep clippy strict for most crates, but avoid churn from toolchain-specific lints
+          # in upstream Zebra code that started firing after the Rust 1.85 toolchain bump.
+          cargo clippy \
+            --workspace --no-deps --all-features --all-targets --locked \
+            --exclude zebra-chain \
+            -- -D warnings
+
+          cargo clippy \
+            -p zebra-chain --no-deps --all-features --all-targets --locked \
+            -- -D warnings \
+               -A elided_named_lifetimes \
+               -A clippy::needless_lifetimes \
+               -A clippy::unnecessary_lazy_evaluations
       - name: Show system resource summary
         run: |
           df -h

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -48,16 +48,18 @@ jobs:
           # fixes and merge conflicts, we allow these lints only for the affected crates for now.
           # TODO: remove this comment and these Clippy exceptions after syncing with updated upstream.
 
-          # 1) Strict clippy for the whole workspace, excluding only crates that currently fail on new 1.85 lints.
+          # Strict workspace (exclude failing crates)
           cargo clippy --workspace --no-deps --all-features --all-targets --locked \
             --exclude zebra-chain \
             --exclude zebra-network \
             --exclude zebra-rpc \
             --exclude zebra-state \
-            --exclude zebra-consensus -- \
+            --exclude zebra-consensus \
+            --exclude tower-fallback \
+            --exclude zebrad -- \
             -D warnings
 
-          # 2) Crates with new 1.85 “style” lints (ok_or_else/map_or/as_bytes/lifetime).
+          # Style-lint group
           cargo clippy -p zebra-chain -p zebra-network -p zebra-rpc --all-features --all-targets --locked -- \
             -D warnings \
             -A elided_named_lifetimes \
@@ -66,10 +68,16 @@ jobs:
             -A clippy::unnecessary_lazy_evaluations \
             -A clippy::unnecessary_map_or
 
-          # 3) Crates that need only the useless_conversion relaxation.
+          # useless_conversion group
           cargo clippy -p zebra-state -p zebra-consensus --all-features --all-targets --locked -- \
             -D warnings \
             -A clippy::useless_conversion
+
+          # rustc-lints-only group
+          cargo clippy -p tower-fallback -p zebrad --all-features --all-targets --locked -- \
+            -D warnings \
+            -A missing_docs \
+            -A non_local_definitions
 
       - name: Show system resource summary
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -47,37 +47,17 @@ jobs:
           # code we don’t want to patch here (and may already be fixed upstream). To avoid carrying
           # fixes and merge conflicts, we allow these lints only for the affected crates for now.
           # TODO: remove this comment and these Clippy exceptions after syncing with updated upstream.
-
-          # Strict workspace (exclude failing crates)
-          cargo clippy --workspace --no-deps --all-features --all-targets --locked \
-            --exclude zebra-chain \
-            --exclude zebra-network \
-            --exclude zebra-rpc \
-            --exclude zebra-state \
-            --exclude zebra-consensus \
-            --exclude tower-fallback \
-            --exclude zebrad -- \
-            -D warnings
-
-          # Style-lint group
-          cargo clippy -p zebra-chain -p zebra-network -p zebra-rpc --all-features --all-targets --locked -- \
+          cargo clippy --workspace --no-deps --all-features --all-targets --locked -- \
             -D warnings \
             -A elided_named_lifetimes \
-            -A clippy::needless_lifetimes \
-            -A clippy::needless_as_bytes \
-            -A clippy::unnecessary_lazy_evaluations \
-            -A clippy::unnecessary_map_or
-
-          # useless_conversion group
-          cargo clippy -p zebra-state -p zebra-consensus --all-features --all-targets --locked -- \
-            -D warnings \
-            -A clippy::useless_conversion
-
-          # rustc-lints-only group
-          cargo clippy -p tower-fallback -p zebrad --all-features --all-targets --locked -- \
-            -D warnings \
             -A missing_docs \
-            -A non_local_definitions
+            -A non_local_definitions \
+            -A clippy::needless_lifetimes \
+            -A clippy::needless_return \
+            -A clippy::unnecessary_lazy_evaluations \
+            -A clippy::unnecessary_map_or \
+            -A clippy::needless_as_bytes \
+            -A clippy::useless_conversion
 
       - name: Show system resource summary
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -48,28 +48,26 @@ jobs:
           # fixes and merge conflicts, we allow these lints only for the affected crates for now.
           # TODO: remove this comment and these Clippy exceptions after syncing with updated upstream.
 
-          # strict for everything except the problematic crates
+          # 1) Strict clippy for the whole workspace, excluding only crates that currently fail on new 1.85 lints.
           cargo clippy --workspace --no-deps --all-features --all-targets --locked \
-            --exclude zebra-chain --exclude zebra-state --exclude zebra-network -- \
+            --exclude zebra-chain \
+            --exclude zebra-network \
+            --exclude zebra-state \
+            --exclude zebra-consensus -- \
             -D warnings
 
-          # zebra-chain: allow only the 3 new lints you saw there
-          cargo clippy -p zebra-chain --all-features --all-targets --locked -- \
+          # 2) Crates that need only “ok_or_else -> ok_or” / string len lint relaxations.
+          cargo clippy -p zebra-chain -p zebra-network --all-features --all-targets --locked -- \
             -D warnings \
             -A elided_named_lifetimes \
             -A clippy::needless_lifetimes \
-            -A clippy::unnecessary_lazy_evaluations
-
-          # zebra-state: allow only what you saw there
-          cargo clippy -p zebra-state --all-features --all-targets --locked -- \
-            -D warnings \
-            -A clippy::useless_conversion
-
-          # zebra-network: allow only what you saw here
-          cargo clippy -p zebra-network --all-features --all-targets --locked -- \
-            -D warnings \
             -A clippy::needless_as_bytes \
             -A clippy::unnecessary_lazy_evaluations
+
+          # 3) Crates that need only the useless_conversion relaxation.
+          cargo clippy -p zebra-state -p zebra-consensus --all-features --all-targets --locked -- \
+            -D warnings \
+            -A clippy::useless_conversion
 
       - name: Show system resource summary
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -43,19 +43,25 @@ jobs:
         run: cargo fmt -- --check
       - name: Run clippy
         run: |
-          # Keep clippy strict for most crates, but avoid churn from toolchain-specific lints
-          # in upstream Zebra code that started firing after the Rust 1.85 toolchain bump.
-          cargo clippy \
-            --workspace --no-deps --all-features --all-targets --locked \
-            --exclude zebra-chain \
-            -- -D warnings
+          # After upgrading from Rust 1.82 to 1.85.1, Clippy started failing on new lints in upstream
+          # code we don’t want to patch here (and may already be fixed upstream). To avoid carrying
+          # fixes and merge conflicts, we allow these lints only for the affected crates for now.
+          # TODO: remove this comment and these Clippy exceptions after syncing with updated upstream.
+          cargo clippy --workspace --no-deps --all-features --all-targets --locked \
+            --exclude zebra-chain --exclude zebra-state -- -D warnings
 
-          cargo clippy \
-            -p zebra-chain --no-deps --all-features --all-targets --locked \
-            -- -D warnings \
-               -A elided_named_lifetimes \
-               -A clippy::needless_lifetimes \
-               -A clippy::unnecessary_lazy_evaluations
+          # relaxed only for zebra-chain (your previous three)
+          cargo clippy -p zebra-chain --all-features --all-targets --locked -- \
+            -D warnings \
+            -A elided_named_lifetimes \
+            -A clippy::needless_lifetimes \
+            -A clippy::unnecessary_lazy_evaluations
+
+          # relaxed only for zebra-state (new)
+          cargo clippy -p zebra-state --all-features --all-targets --locked -- \
+            -D warnings \
+            -A clippy::useless_conversion
+
       - name: Show system resource summary
         run: |
           df -h

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -52,17 +52,19 @@ jobs:
           cargo clippy --workspace --no-deps --all-features --all-targets --locked \
             --exclude zebra-chain \
             --exclude zebra-network \
+            --exclude zebra-rpc \
             --exclude zebra-state \
             --exclude zebra-consensus -- \
             -D warnings
 
-          # 2) Crates that need only “ok_or_else -> ok_or” / string len lint relaxations.
-          cargo clippy -p zebra-chain -p zebra-network --all-features --all-targets --locked -- \
+          # 2) Crates with new 1.85 “style” lints (ok_or_else/map_or/as_bytes/lifetime).
+          cargo clippy -p zebra-chain -p zebra-network -p zebra-rpc --all-features --all-targets --locked -- \
             -D warnings \
             -A elided_named_lifetimes \
             -A clippy::needless_lifetimes \
             -A clippy::needless_as_bytes \
-            -A clippy::unnecessary_lazy_evaluations
+            -A clippy::unnecessary_lazy_evaluations \
+            -A clippy::unnecessary_map_or
 
           # 3) Crates that need only the useless_conversion relaxation.
           cargo clippy -p zebra-state -p zebra-consensus --all-features --all-targets --locked -- \

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -47,20 +47,29 @@ jobs:
           # code we don’t want to patch here (and may already be fixed upstream). To avoid carrying
           # fixes and merge conflicts, we allow these lints only for the affected crates for now.
           # TODO: remove this comment and these Clippy exceptions after syncing with updated upstream.
-          cargo clippy --workspace --no-deps --all-features --all-targets --locked \
-            --exclude zebra-chain --exclude zebra-state -- -D warnings
 
-          # relaxed only for zebra-chain (your previous three)
+          # strict for everything except the problematic crates
+          cargo clippy --workspace --no-deps --all-features --all-targets --locked \
+            --exclude zebra-chain --exclude zebra-state --exclude zebra-network -- \
+            -D warnings
+
+          # zebra-chain: allow only the 3 new lints you saw there
           cargo clippy -p zebra-chain --all-features --all-targets --locked -- \
             -D warnings \
             -A elided_named_lifetimes \
             -A clippy::needless_lifetimes \
             -A clippy::unnecessary_lazy_evaluations
 
-          # relaxed only for zebra-state (new)
+          # zebra-state: allow only what you saw there
           cargo clippy -p zebra-state --all-features --all-targets --locked -- \
             -D warnings \
             -A clippy::useless_conversion
+
+          # zebra-network: allow only what you saw here
+          cargo clippy -p zebra-network --all-features --all-targets --locked -- \
+            -D warnings \
+            -A clippy::needless_as_bytes \
+            -A clippy::unnecessary_lazy_evaluations
 
       - name: Show system resource summary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6629,8 +6629,3 @@ dependencies = [
  "zcash_address",
  "zcash_protocol",
 ]
-
-[[patch.unused]]
-name = "halo2_gadgets"
-version = "0.3.1"
-source = "git+https://github.com/zcash/halo2?rev=2308caf68c48c02468b66cfc452dad54e355e32f#2308caf68c48c02468b66cfc452dad54e355e32f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,12 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,13 +495,13 @@ dependencies = [
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.2.6",
 ]
 
 [[package]]
@@ -518,7 +512,7 @@ checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.3.0",
 ]
 
 [[package]]
@@ -956,6 +950,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
@@ -1078,18 +1078,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -1245,7 +1233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common 0.1.6",
 ]
 
@@ -1295,18 +1282,6 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "signature",
-]
 
 [[package]]
 name = "ed25519"
@@ -1362,24 +1337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1449,7 +1406,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1665,7 +1622,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -2488,19 +2444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if 1.0.0",
- "ecdsa",
- "elliptic-curve",
- "sha2 0.10.8",
- "signature",
-]
-
-[[package]]
 name = "known-folders"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,7 +2894,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?branch=pr471_issuance_empty_hashes#bf0a4b69288537f080c15b4bed9eafa042aa7e7c"
+source = "git+https://github.com/QED-it/orchard?rev=382f31921f0382743a9d96ae6a0003a28ab5dc5c#382f31921f0382743a9d96ae6a0003a28ab5dc5c"
 dependencies = [
  "aes",
  "bitvec",
@@ -2966,7 +2909,6 @@ dependencies = [
  "halo2_proofs",
  "hex",
  "incrementalmerkletree",
- "k256",
  "lazy_static",
  "memuse",
  "nonempty 0.11.0",
@@ -2975,6 +2917,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "reddsa",
+ "secp256k1 0.29.1",
  "serde",
  "sinsemilla",
  "subtle",
@@ -4052,19 +3995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,6 +4010,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
+ "rand 0.8.5",
  "secp256k1-sys 0.10.1",
 ]
 
@@ -4426,7 +4357,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5929,7 +5859,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.9.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "bech32",
  "bs58",
@@ -5942,7 +5872,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.20.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5984,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "core2",
  "nonempty 0.11.0",
@@ -5993,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6003,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6041,7 +5971,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6083,7 +6013,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6105,7 +6035,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.6.2"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "core2",
  "document-features",
@@ -6149,7 +6079,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6691,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
+source = "git+https://github.com/QED-it/librustzcash?rev=87e0128f3f35bcdd6fddac5c2de22b81d869d51a#87e0128f3f35bcdd6fddac5c2de22b81d869d51a"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2950,7 +2950,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?rev=2083efe8d57e6073914ae296db2d41f8bfe1de50#2083efe8d57e6073914ae296db2d41f8bfe1de50"
+source = "git+https://github.com/QED-it/orchard?rev=927f40eb6f130fbd8074abab00934ce5758b23f3#927f40eb6f130fbd8074abab00934ce5758b23f3"
 dependencies = [
  "aes",
  "bitvec",
@@ -5928,7 +5928,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.9.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "bech32",
  "bs58",
@@ -5941,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.20.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "core2",
  "nonempty 0.11.0",
@@ -5992,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6002,7 +6002,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6040,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.6.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "core2",
  "document-features",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6690,7 +6690,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=e27124a49a0e549227e12adf13e42f88593f1dee#e27124a49a0e549227e12adf13e42f88593f1dee"
+source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "blake2b_simd",
  "core2",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1803,8 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.1"
-source = "git+https://github.com/zcash/halo2?rev=2308caf68c48c02468b66cfc452dad54e355e32f#2308caf68c48c02468b66cfc452dad54e355e32f"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2950,7 +2951,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/orchard?rev=927f40eb6f130fbd8074abab00934ce5758b23f3#927f40eb6f130fbd8074abab00934ce5758b23f3"
+source = "git+https://github.com/QED-it/orchard?branch=pr471_issuance_empty_hashes#bf0a4b69288537f080c15b4bed9eafa042aa7e7c"
 dependencies = [
  "aes",
  "bitvec",
@@ -5928,7 +5929,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.9.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "bech32",
  "bs58",
@@ -5941,7 +5942,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.20.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5983,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "core2",
  "nonempty 0.11.0",
@@ -5992,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -6002,7 +6003,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.11.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -6040,7 +6041,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6082,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.25.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6104,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.6.2"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "core2",
  "document-features",
@@ -6148,7 +6149,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -6690,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.5.0"
-source = "git+https://github.com/QED-it/librustzcash?rev=bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52#bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52"
+source = "git+https://github.com/QED-it/librustzcash?branch=pr471_zsa_issuance_flag_followups#d4996baff7aedab3502b0e0bc297742047815115"
 dependencies = [
  "base64 0.22.1",
  "nom",
@@ -6698,3 +6699,8 @@ dependencies = [
  "zcash_address",
  "zcash_protocol",
 ]
+
+[[patch.unused]]
+name = "halo2_gadgets"
+version = "0.3.1"
+source = "git+https://github.com/zcash/halo2?rev=2308caf68c48c02468b66cfc452dad54e355e32f#2308caf68c48c02468b66cfc452dad54e355e32f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,6 @@ lto = "thin"
 
 [patch.crates-io]
 halo2_proofs = { version = "0.3.0", git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
-halo2_gadgets = { version = "0.3.0", git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
 halo2_poseidon = { version = "0.1.0", git = "https://github.com/zcash/halo2", rev = "2308caf68c48c02468b66cfc452dad54e355e32f" }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,14 +113,14 @@ halo2_poseidon = { version = "0.1.0", git = "https://github.com/zcash/halo2", re
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
 sapling-crypto = { package = "sapling-crypto", version = "0.5", git = "https://github.com/QED-it/sapling-crypto", rev = "9393f93fe547d1b3738c9f4618c0f8a2fffed29f" }
-orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "2083efe8d57e6073914ae296db2d41f8bfe1de50" }
-zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
-equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", rev = "e27124a49a0e549227e12adf13e42f88593f1dee" }
+orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "927f40eb6f130fbd8074abab00934ce5758b23f3" }
+zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,14 +113,14 @@ halo2_poseidon = { version = "0.1.0", git = "https://github.com/zcash/halo2", re
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
 sapling-crypto = { package = "sapling-crypto", version = "0.5", git = "https://github.com/QED-it/sapling-crypto", rev = "9393f93fe547d1b3738c9f4618c0f8a2fffed29f" }
-orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", branch = "pr471_issuance_empty_hashes" }
-zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
-equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "382f31921f0382743a9d96ae6a0003a28ab5dc5c" }
+zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }
+equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", rev = "87e0128f3f35bcdd6fddac5c2de22b81d869d51a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,14 +113,14 @@ halo2_poseidon = { version = "0.1.0", git = "https://github.com/zcash/halo2", re
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c" }
 zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }
 sapling-crypto = { package = "sapling-crypto", version = "0.5", git = "https://github.com/QED-it/sapling-crypto", rev = "9393f93fe547d1b3738c9f4618c0f8a2fffed29f" }
-orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", rev = "927f40eb6f130fbd8074abab00934ce5758b23f3" }
-zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
-equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", rev = "bd6b6a1bbcd267b9b7c13c7923ca5d61b2addd52" }
+orchard = { version = "0.11.0", git = "https://github.com/QED-it/orchard", branch = "pr471_issuance_empty_hashes" }
+zcash_primitives = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_protocol = { version = "0.6.2", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_address = { version = "0.9.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_encoding = { version = "0.3.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_history = { version = "0.4.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_client_backend = { version = "0.20.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_keys = { version = "0.11.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_transparent = { version = "0.5.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+zcash_proofs = { version = "0.25.0", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }
+equihash = { version = "0.2.2", git = "https://github.com/QED-it/librustzcash", branch = "pr471_zsa_issuance_flag_followups" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # TODO: Upstream specifies `channel = "stable"` — consider restoring it before final merge.
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.1"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -72,7 +72,7 @@ tx_v6 = [
 bitvec = "1.0.1"
 bitflags = "2.5.0"
 bitflags-serde-legacy = "0.1.1"
-blake2b_simd = "1.0.2"
+blake2b_simd = "=1.0.1"
 blake2s_simd = "1.0.2"
 bridgetree = "0.7.0"
 bs58 = { version = "0.5.1", features = ["check"] }

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -243,8 +243,6 @@ impl ValueCommitment {
         let rcv = generate_trapdoor(csprng)?;
 
         #[cfg(feature = "tx_v6")]
-        // FIXME: ValueSum::from_raw doesn't compile because ValueSum::from_raw
-        // isn't public in Orchard. We should discuss how to fix this.
         let vc = Self::new(rcv, ValueSum::from_raw(value.into()), AssetBase::native());
 
         #[cfg(not(feature = "tx_v6"))]

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -236,7 +236,6 @@ impl ValueCommitment {
     /// Generate a new _ValueCommitment_.
     ///
     /// <https://zips.z.cash/protocol/nu5.pdf#concretehomomorphiccommit>
-    #[allow(clippy::unwrap_in_result)]
     pub fn randomized<T>(csprng: &mut T, value: Amount) -> Result<Self, RandError>
     where
         T: RngCore + CryptoRng,
@@ -244,14 +243,9 @@ impl ValueCommitment {
         let rcv = generate_trapdoor(csprng)?;
 
         #[cfg(feature = "tx_v6")]
-        let vc = Self::new(
-            rcv,
-            // TODO: Make the `ValueSum::from_raw` function public in the `orchard` crate
-            // and use `ValueSum::from_raw(value.into())` instead of the next line.
-            // Remove `#[allow(clippy::unwrap_in_result)]` after doing so.
-            (ValueSum::default() + i64::from(value)).unwrap(),
-            AssetBase::native(),
-        );
+        // FIXME: ValueSum::from_raw doesn't compile because ValueSum::from_raw
+        // isn't public in Orchard. We should discuss how to fix this.
+        let vc = Self::new(rcv, ValueSum::from_raw(value.into()), AssetBase::native());
 
         #[cfg(not(feature = "tx_v6"))]
         let vc = Self::new(rcv, value);

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -133,10 +133,9 @@ impl<Flavor: ShieldedDataFlavor> ShieldedData<Flavor> {
         let key = {
             let cv_balance = ValueCommitment::new(
                 pallas::Scalar::zero(),
-                // TODO: Make the `ValueSum::from_raw` function public in the `orchard` crate
-                // and use `ValueSum::from_raw(self.value_balance.into())` instead of the
-                // next line
-                (ValueSum::default() + i64::from(self.value_balance)).unwrap(),
+                // FIXME: ValueSum::from_raw conversion does not compile as ValueSum::from_raw
+                // is not pub in orchard - we should discuss possible ways to fix it.
+                ValueSum::from_raw(self.value_balance.into()),
                 AssetBase::native(),
             );
             let burn_value_commitment = compute_burn_value_commitment(self.burn.as_ref());

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -133,8 +133,6 @@ impl<Flavor: ShieldedDataFlavor> ShieldedData<Flavor> {
         let key = {
             let cv_balance = ValueCommitment::new(
                 pallas::Scalar::zero(),
-                // FIXME: ValueSum::from_raw conversion does not compile as ValueSum::from_raw
-                // is not pub in orchard - we should discuss possible ways to fix it.
                 ValueSum::from_raw(self.value_balance.into()),
                 AssetBase::native(),
             );

--- a/zebra-chain/src/orchard/shielded_data_flavor.rs
+++ b/zebra-chain/src/orchard/shielded_data_flavor.rs
@@ -4,12 +4,12 @@ use std::fmt::Debug;
 
 use serde::{de::DeserializeOwned, Serialize};
 
-use orchard::{orchard_flavor::OrchardFlavor, primitives::OrchardPrimitives};
+use orchard::{flavor::OrchardFlavor, primitives::OrchardPrimitives};
 
-pub use orchard::orchard_flavor::OrchardVanilla;
+pub use orchard::flavor::OrchardVanilla;
 
 #[cfg(feature = "tx_v6")]
-pub use orchard::{note::AssetBase, orchard_flavor::OrchardZSA, value::NoteValue};
+pub use orchard::{note::AssetBase, flavor::OrchardZSA, value::NoteValue};
 
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 

--- a/zebra-chain/src/orchard/shielded_data_flavor.rs
+++ b/zebra-chain/src/orchard/shielded_data_flavor.rs
@@ -9,7 +9,7 @@ use orchard::{flavor::OrchardFlavor, primitives::OrchardPrimitives};
 pub use orchard::flavor::OrchardVanilla;
 
 #[cfg(feature = "tx_v6")]
-pub use orchard::{note::AssetBase, flavor::OrchardZSA, value::NoteValue};
+pub use orchard::{flavor::OrchardZSA, note::AssetBase, value::NoteValue};
 
 use crate::serialization::{ZcashDeserialize, ZcashSerialize};
 

--- a/zebra-chain/src/orchard_zsa/arbitrary.rs
+++ b/zebra-chain/src/orchard_zsa/arbitrary.rs
@@ -15,7 +15,7 @@ impl Arbitrary for BurnItem {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        BundleArb::<orchard::orchard_flavor::OrchardVanilla>::arb_asset_to_burn()
+        BundleArb::<orchard::flavor::OrchardVanilla>::arb_asset_to_burn()
             .prop_map(|(asset_base, value)| BurnItem::from((asset_base, value)))
             .boxed()
     }

--- a/zebra-chain/src/orchard_zsa/burn.rs
+++ b/zebra-chain/src/orchard_zsa/burn.rs
@@ -171,7 +171,11 @@ impl ZcashDeserialize for Burn {
 pub(crate) fn compute_burn_value_commitment(burn: &[BurnItem]) -> ValueCommitment {
     burn.iter()
         .map(|&BurnItem(asset, amount)| {
-            ValueCommitment::new(pallas::Scalar::zero(), amount.into(), asset)
+            ValueCommitment::new(
+                pallas::Scalar::zero(),
+                amount - NoteValue::from_raw(0),
+                asset,
+            )
         })
         .sum()
 }

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -30,8 +30,10 @@ lazy_static! {
         sapling_shielded_data: None,
         orchard_shielded_data: None,
     };
+}
 
-    #[cfg(feature = "tx_v6")]
+#[cfg(feature = "tx_v6")]
+lazy_static! {
     pub static ref EMPTY_V6_TX: Transaction = Transaction::V6 {
         network_upgrade: NetworkUpgrade::Nu7,
         lock_time: LockTime::min_lock_time_timestamp(),

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -41,7 +41,7 @@ tx_v6 = [
 ]
 
 [dependencies]
-blake2b_simd = "1.0.2"
+blake2b_simd = "=1.0.1"
 bellman = "0.14.0"
 bls12_381 = "0.8.0"
 halo2 = { package = "halo2_proofs", version = "0.3.0" }

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -68,7 +68,11 @@ where
                     .unwrap();
             }
 
-            let bundle: Bundle<_, i64, Flavor> = builder.build(rng).unwrap().expect("Bundle should not be None").0;
+            let bundle: Bundle<_, i64, Flavor> = builder
+                .build(rng)
+                .unwrap()
+                .expect("Bundle should not be None")
+                .0;
 
             let bundle = bundle
                 .create_proof(&proving_key, rng)

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -68,7 +68,7 @@ where
                     .unwrap();
             }
 
-            let bundle: Bundle<_, i64, Flavor> = builder.build(rng).unwrap().0;
+            let bundle: Bundle<_, i64, Flavor> = builder.build(rng).unwrap().expect("Bundle should not be None").0;
 
             let bundle = bundle
                 .create_proof(&proving_key, rng)


### PR DESCRIPTION
This PR updates Zebra to use the current `orchard` and `librustzcash` crate versions that contain the upstream Orchard PR https://github.com/zcash/orchard/pull/471 review-related changes.

Other than updating the `orchard` and `librustzcash` references in `Cargo.toml` it also includes the follow-up changes needed to keep Zebra building against the updated `orchard`/`librustzcash` APIs:

* Adjust `NoteValue` → `ValueSum` conversions (including updating `orchard_zsa/burn.rs`, and switching `zebra-chain` to `ValueSum::from_raw` where needed). This is a placeholder change and the code does not compile yet — see the `FIXME` comments and the note below.
* Fix test vectors so they compile when `zcash_unstable="nu7"` is enabled but `tx_v6` is not.
* Rename the `orchard_flavor` module to `flavor`.
* Update Orchard's `Bundle::build` usage in `zebra-consensus` tests.
* Upgrade Rust to 1.85.1 (to align with `librustzcash`) and downgrade the `blake2b_simd` dependency to `1.0.1` to align with `orchard`.
* Remove `halo2_gadgets` patch in Cargo.toml