### PR TITLE
Add logs endpoint for swaps - logs.zebra-swaps.zsa-test.net

### DIFF
--- a/testnet-single-node-deploy/infra/terraform-aws-modules/cicd-user/main.tf
+++ b/testnet-single-node-deploy/infra/terraform-aws-modules/cicd-user/main.tf
@@ -46,7 +46,10 @@ resource "aws_iam_policy" "ecr_ecs_policy" {
         Action = [
           "lambda:*"
         ]
-        Resource = "arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:function:watch-zebra-logs"
+        Resource = [
+          "arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:function:watch-zebra-logs",
+          "arn:aws:lambda:${var.aws_region}:${var.aws_account_id}:function:watch-zebra-swaps-logs"
+        ]
       },
       {
         # The CICD user needs the iam:PassRole permission to pass the ECS execution role when registering task definitions.
@@ -81,7 +84,7 @@ resource "aws_secretsmanager_secret" "credentials" {
 }
 
 resource "aws_secretsmanager_secret_version" "credentials_version" {
-  secret_id     = aws_secretsmanager_secret.credentials.id
+  secret_id = aws_secretsmanager_secret.credentials.id
   secret_string = jsonencode({
     AWS_ACCESS_KEY_ID     = aws_iam_access_key.cicd_user_key.id,
     AWS_SECRET_ACCESS_KEY = aws_iam_access_key.cicd_user_key.secret

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/api-gw/.terraform.lock.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/api-gw/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 4.40.0, >= 5.37.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/api-gw/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/api-gw/terragrunt.hcl
@@ -1,0 +1,82 @@
+locals {
+  name        = "watch-swaps-logs"
+  domain_name = "zsa-test.net"
+
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-apigateway-v2?ref=v5.2.1"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "lambda" {
+  config_path = "../lambda"
+}
+
+inputs = {
+  name        = local.name
+  description = "Simple HTTP API Gateway forwarding to Lambda"
+
+  # Create and configure the domain
+  domain_name           = "logs.zebra-swaps.${local.domain_name}"
+  create_domain_records = true
+  create_certificate    = true
+  hosted_zone_name      = local.domain_name
+
+  # Basic CORS configuration
+  cors_configuration = {
+    allow_headers = ["content-type", "x-amz-date", "authorization", "x-api-key", "x-amz-security-token", "x-amz-user-agent"]
+    allow_methods = ["*"]
+    allow_origins = ["*"]
+  }
+
+  # Simplified route configuration - forward everything to Lambda
+  routes = {
+    "ANY /" = {
+      integration = {
+        uri                    = dependency.lambda.outputs.lambda_function_arn
+        payload_format_version = "2.0"
+        integration_type       = "AWS_PROXY"
+      }
+    }
+  }
+
+  # Basic stage configuration
+  stage_access_log_settings = {
+    create_log_group            = true
+    log_group_retention_in_days = 7
+    format = jsonencode({
+      requestId    = "$context.requestId"
+      requestTime  = "$context.requestTime"
+      status       = "$context.status"
+      errorMessage = "$context.error.message"
+      integration = {
+        error  = "$context.integration.error"
+        status = "$context.integration.integrationStatus"
+      }
+    })
+  }
+
+  # Default stage settings
+  stage_default_route_settings = {
+    detailed_metrics_enabled = true
+    throttling_burst_limit   = 100
+    throttling_rate_limit    = 100
+  }
+
+  tags = {
+    Environment = local.env
+    Project     = "zebra-swaps-logs"
+  }
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-ecr-policy/.terraform.lock.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-ecr-policy/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-ecr-policy/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-ecr-policy/terragrunt.hcl
@@ -1,0 +1,41 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-policy?ref=v5.52.2"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  create_policy = true
+
+  name = "zebra-swaps-lambda-ecr-access"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "arn:aws:ecr:${local.region_vars.locals.aws_region}:${local.account_vars.locals.aws_account_id}:repository/*"
+      }
+    ]
+  })
+
+  tags = {
+    Environment = local.env
+    Project     = "zebra-swaps-logs"
+  }
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-read-policy/.terraform.lock.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-read-policy/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-read-policy/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-read-policy/terragrunt.hcl
@@ -1,0 +1,44 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-policy?ref=v5.52.2"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+inputs = {
+  create_policy = true
+
+  name = "lambda-zebra-swaps-read-logs"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:PutLogEvents",
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup"
+        ]
+        Resource = "arn:aws:logs:${local.region_vars.locals.aws_region}:${local.account_vars.locals.aws_account_id}:log-group:/dev/ecs/zebra-swaps-task:*"
+      }
+    ]
+  })
+
+  tags = {
+    Environment = local.env
+    Project     = "zebra-swaps-logs"
+  }
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-role/.terraform.lock.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-role/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-role/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/iam/lambda-role/terragrunt.hcl
@@ -1,0 +1,46 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+  region_vars      = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  account_vars     = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-iam//modules/iam-assumable-role?ref=v5.52.2"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "lambda-ecr-policy" {
+  config_path = "../lambda-ecr-policy"
+}
+
+dependency "lambda-read-policy" {
+  config_path = "../lambda-read-policy"
+}
+
+inputs = {
+  create_role           = true
+  role_name             = "lambda-zebra-swaps-logs-role"
+  trusted_role_services = ["lambda.amazonaws.com"]
+  max_session_duration  = 3600
+  description           = "Role for accessing Zebra swaps logs for the lambda function"
+
+  role_requires_mfa = false
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    dependency.lambda-ecr-policy.outputs.arn,
+    dependency.lambda-read-policy.outputs.arn,
+  ]
+
+  tags = {
+    Environment = local.env
+    Project     = "zebra-swaps-logs"
+    Terraform   = "true"
+  }
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/lambda/.terraform.lock.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/lambda/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 5.79.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.3.5"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.8.0"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/lambda/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda-swaps/lambda/terragrunt.hcl
@@ -1,0 +1,66 @@
+locals {
+  # Automatically load environment-level variables
+  environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
+
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  # Extract out common variables for reuse
+  env = local.environment_vars.locals.environment
+}
+
+terraform {
+  source = "github.com/terraform-aws-modules/terraform-aws-lambda?ref=v7.20.1"
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "ecr" {
+  config_path = "../../lambda/ecr-logs"
+}
+
+dependency "lambda-role" {
+  config_path = "../iam/lambda-role"
+}
+
+inputs = {
+  function_name          = "watch-zebra-swaps-logs"
+  description            = "A simple lambda function to publicly expose logs from the Zebra swaps ECS task"
+  memory_size            = 128
+  timeout                = 300
+  architectures          = ["x86_64"]
+  package_type           = "Image"
+  image_uri              = "${dependency.ecr.outputs.ecr-url}:latest"
+  create_role            = false
+  lambda_role            = dependency.lambda-role.outputs.iam_role_arn
+  ephemeral_storage_size = 512
+  tracing_config_mode    = "PassThrough"
+
+  environment_variables = {
+    LOG_GROUP_NAME = "/dev/ecs/zebra-swaps-task"
+  }
+
+  # To create a version after the initial
+  publish = true
+
+  # Add allowed triggers for API Gateway
+  allowed_triggers = {
+    APIGatewayAny = {
+      service    = "apigateway"
+      source_arn = "arn:aws:execute-api:${local.region_vars.locals.aws_region}:${local.account_vars.locals.aws_account_id}:*/*/*"
+    }
+  }
+
+  create_package             = false
+  create_lambda_function_url = true
+
+  cloudwatch_log_group_name        = "/aws/lambda/zebra-swaps-logs"
+  cloudwatch_log_retention_in_days = 14
+
+  tags = {
+    Environment = local.env
+    Terraform   = "true"
+  }
+}


### PR DESCRIPTION
- Add a dedicated swaps logs endpoint stack under `lambda-swaps`.
- Provision API Gateway, Lambda, IAM role, and log-read/ECR policies for `watch-zebra-swaps-logs`.
- Configure the swaps logs Lambda to read `/dev/ecs/zebra-swaps-task` and expose it via `logs.zebra-swaps.zsa-test.net`.
- Allow the CI/CD user to update both the regular logs Lambda and the swaps logs Lambda.