### PR TITLE
Fix upstream CI issues and improve basic CI with nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -130,3 +130,13 @@ default-filter = 'package(zebrad) and test(=lightwalletd_test_suite)'
 [profile.rpc-z-getsubtreesbyindex-snapshot]
 slow-timeout = { period = "30m", terminate-after = 2 }
 default-filter = 'package(zebrad) and test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test)'
+
+# --- QEDIT temporary retries ---
+
+# TODO: Remove retries after investigating periodic random failures.
+# Add more tests here only after confirming similar intermittent failures.
+[[profile.default.overrides]]
+filter = '''
+test(=sync_large_checkpoints_mempool_mainnet)
+'''
+retries = 3

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,6 +2,9 @@ name: Basic checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,10 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -35,6 +41,7 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
+
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -47,16 +54,44 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run tests
+      - name: Run non-network tests
+        env:
+          SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
+
+      - name: Run network-sensitive tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "network-sensitive tests attempt ${attempt}"
+
+            timeout --preserve-status 45m bash -c '
+              set -euo pipefail
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
+            ' && exit 0
+
+            status=$?
+            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
+
       - name: Run format check
         run: cargo fmt -- --check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
+
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -59,19 +59,47 @@ jobs:
           SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
 
-      - name: Run network-sensitive tests
+      # Build the network-sensitive test binaries outside the retry loops so
+      # compile failures fail once instead of being retried, and retry
+      # attempts below contain only test runtime.
+      - name: Build network-sensitive tests
+        run: |
+          cargo test -p zebra-network --lib --verbose --locked --no-run
+          cargo test -p zebrad --test acceptance --verbose --locked --no-run
+
+      # The two network-sensitive suites are retried independently so a flaky
+      # failure in one does not re-run the other. Per-attempt timeouts are
+      # sized from measured serial test runtimes (~15m and ~19m) plus headroom.
+      - name: Run zebra-network tests
         run: |
           for attempt in 1 2 3; do
-            echo "network-sensitive tests attempt ${attempt}"
+            echo "zebra-network tests attempt ${attempt}"
 
-            timeout --preserve-status 45m bash -c '
-              set -euo pipefail
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
-            ' && exit 0
+            timeout --preserve-status 25m \
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1 \
+              && exit 0
 
             status=$?
-            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
+            echo "zebra-network tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
+      - name: Run zebrad acceptance tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "zebrad acceptance tests attempt ${attempt}"
+
+            timeout --preserve-status 30m \
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1 \
+              && exit 0
+
+            status=$?
+            echo "zebrad acceptance tests attempt ${attempt} failed with status ${status}"
 
             if [ "${attempt}" = "3" ]; then
               exit "${status}"

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -75,6 +75,11 @@ jobs:
             cargo nextest run -p zebrad --test acceptance --locked \
               --retries 3
 
+      - name: Run doc tests
+        run: |
+          timeout --preserve-status 30m \
+            cargo test --doc --workspace --locked
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -55,7 +55,7 @@ jobs:
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@305bebabd4457bed9b82541755f034994382465b #v2.68.10
 
       - name: Run regular tests
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -59,23 +59,10 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Run regular tests
+      - name: Run tests
         run: |
           timeout --preserve-status 1h \
-            cargo nextest run --workspace --locked \
-              -E 'not package(zebra-network) and not binary(acceptance)'
-
-      - name: Run zebra-network tests
-        run: |
-          timeout --preserve-status 30m \
-            cargo nextest run -p zebra-network --locked \
-              --retries 3
-
-      - name: Run zebrad acceptance tests
-        run: |
-          timeout --preserve-status 1h \
-            cargo nextest run -p zebrad --test acceptance --locked \
-              --retries 3
+            cargo nextest run --workspace --locked
 
       - name: Run doc tests
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -57,56 +57,31 @@ jobs:
       - name: Run non-network tests
         env:
           SKIP_NETWORK_TESTS: "1"
-        run: timeout --preserve-status 1h cargo test --verbose --locked
-
-      # Build the network-sensitive test binaries outside the retry loops so
-      # compile failures fail once instead of being retried, and retry
-      # attempts below contain only test runtime.
-      - name: Build network-sensitive tests
         run: |
-          cargo test -p zebra-network --lib --verbose --locked --no-run
-          cargo test -p zebrad --test acceptance --verbose --locked --no-run
+          timeout --preserve-status 1h cargo test --verbose --locked -- \
+            --skip trusted_chain_sync_handles_forks_correctly
 
-      # The two network-sensitive suites are retried independently so a flaky
-      # failure in one does not re-run the other. Per-attempt timeouts are
-      # sized from measured serial test runtimes (~15m and ~19m) plus headroom.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run regular tests
+        run: |
+          timeout --preserve-status 1h \
+            cargo nextest run --workspace --locked \
+              -E 'not package(zebra-network) and not binary(acceptance)'
+
       - name: Run zebra-network tests
         run: |
-          for attempt in 1 2 3; do
-            echo "zebra-network tests attempt ${attempt}"
-
-            timeout --preserve-status 25m \
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1 \
-              && exit 0
-
-            status=$?
-            echo "zebra-network tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
+          timeout --preserve-status 30m \
+            cargo nextest run -p zebra-network --locked \
+              --retries 3
 
       - name: Run zebrad acceptance tests
         run: |
-          for attempt in 1 2 3; do
-            echo "zebrad acceptance tests attempt ${attempt}"
-
-            timeout --preserve-status 30m \
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1 \
-              && exit 0
-
-            status=$?
-            echo "zebrad acceptance tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
+          timeout --preserve-status 1h \
+            cargo nextest run -p zebrad --test acceptance --locked \
+              --retries 3 \
+              --test-threads 4
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -80,8 +80,7 @@ jobs:
         run: |
           timeout --preserve-status 1h \
             cargo nextest run -p zebrad --test acceptance --locked \
-              --retries 3 \
-              --test-threads 4
+              --retries 3
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -55,7 +55,9 @@ jobs:
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@305bebabd4457bed9b82541755f034994382465b #v2.68.10
+        uses: taiki-e/install-action@305bebabd4457bed9b82541755f034994382465b # v2.68.10
+        with:
+          tool: cargo-nextest
 
       - name: Run regular tests
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -54,13 +54,6 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run non-network tests
-        env:
-          SKIP_NETWORK_TESTS: "1"
-        run: |
-          timeout --preserve-status 1h cargo test --verbose --locked -- \
-            --skip trusted_chain_sync_handles_forks_correctly
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    # Temporarily allow CI on the QEDIT integration branch.
+    # TODO: Remove v4.2.0-dev before merging upstream.
+    branches:
+      - main
+      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -12,7 +16,11 @@ on:
       - .github/workflows/lint.yml
 
   push:
-    branches: [main]
+    # Temporarily allow CI on the QEDIT integration branch.
+    # TODO: Remove v4.2.0-dev before merging upstream.
+    branches:
+      - main
+      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,9 @@ name: Lint
 
 on:
   pull_request:
-    # Temporarily allow CI on the QEDIT integration branch.
-    # TODO: Remove v4.2.0-dev before merging upstream.
     branches:
-      - main
-      - v4.2.0-dev
+      main
+      zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -16,11 +14,7 @@ on:
       - .github/workflows/lint.yml
 
   push:
-    # Temporarily allow CI on the QEDIT integration branch.
-    # TODO: Remove v4.2.0-dev before merging upstream.
-    branches:
-      - main
-      - v4.2.0-dev
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - zsa1
+      - zsa-support
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust-version: [stable, beta]
+        # TODO: QED-it temporary Rust 1.94 pin: stable when testing Zebra v4.2.0 on upstream CI; remove before upstream merge.
+        rust-version: [1.94]
         type: [release, tests]
         include:
           - type: release
@@ -69,8 +70,7 @@ jobs:
           cache-on-failure: true
       - uses: ./.github/actions/setup-zebra-build
       - name: Run clippy
-        # TODO: Temporary QED-it fork exception for clippy::manual_option_zip; remove before merging this branch upstream.
-        run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}" -- -A unknown-lints -A clippy::manual_option_zip
+        run: cargo clippy ${{ matrix.args }} --features "${{ matrix.features }}"
 
   crate-checks:
     permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Lint
 on:
   pull_request:
     branches:
-      main
-      zsa1
+      - main
+      - zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,8 +164,8 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
-          # TODO: QED-it temp Rust 1.94 pin: stable for Zebra v4.2.0 CI; remove before upstream merge.
-          toolchain: "1.94"
+          # TODO: QED-it temp nightly pin: matches Zebra v4.2.0 CI test period; remove before upstream merge.
+          toolchain: nightly-2026-03-06
           cache-on-failure: true
       - uses: taiki-e/install-action@305bebabd4457bed9b82541755f034994382465b #v2.68.10
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,11 +164,13 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
-          toolchain: nightly
+          # TODO: QED-it temp Rust 1.94 pin: stable for Zebra v4.2.0 CI; remove before upstream merge.
+          toolchain: "1.94"
           cache-on-failure: true
       - uses: taiki-e/install-action@305bebabd4457bed9b82541755f034994382465b #v2.68.10
         with:
-          tool: cargo-udeps
+          # TODO: QED-it temp cargo-udeps 0.1.60 pin: stable for Zebra v4.2.0 CI; remove before upstream merge.
+          tool: cargo-udeps@0.1.60
       - uses: ./.github/actions/setup-zebra-build
       - run: cargo udeps --workspace --all-targets --all-features --locked
 

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -59,7 +59,8 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
-          toolchain: stable
+          # TODO: QED-it temp Rust 1.94 pin: stable for Zebra v4.2.0 CI; remove before upstream merge.
+          toolchain: "1.94"
           components: clippy
           cache-on-failure: true
       - uses: ./.github/actions/setup-zebra-build

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -3,8 +3,8 @@ name: Test Crate Build
 on:
   pull_request:
     branches:
-      main
-      zsa1
+      - main
+      - zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -185,7 +185,6 @@ jobs:
         run: |
           cargo clippy --package ${{ matrix.crate }} --all-features --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --all-features --all-targets
-
 
   test-crate-build-success:
     name: test crate build success

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - zsa1
+      - zsa-support
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -112,7 +112,8 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
-          toolchain: stable
+          # TODO: QED-it temp Rust 1.94 pin: stable for Zebra v4.2.0 CI; remove before upstream merge.
+          toolchain: "1.94"
           components: clippy
           cache-key: crate-build-${{ matrix.crate }}
           cache-on-failure: true

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -2,7 +2,9 @@ name: Test Crate Build
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      main
+      zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - zsa1
+      - zsa-support
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -3,8 +3,8 @@ name: Test Docker Config
 on:
   pull_request:
     branches:
-      main
-      zsa1
+      - main
+      - zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -2,7 +2,9 @@ name: Test Docker Config
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      main
+      zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -2,7 +2,9 @@ name: Unit Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      main
+      zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -3,8 +3,8 @@ name: Unit Tests
 on:
   pull_request:
     branches:
-      main
-      zsa1
+      - main
+      - zsa1
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - zsa1
+      - zsa-support
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -97,7 +97,8 @@ jobs:
           echo "PROPTEST_MAX_SHRINK_ITERS=1024" >> $GITHUB_ENV
 
       - name: Run unit tests
-        run: cargo nextest run --profile all-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all
+        # TODO: Remove retries after investigating periodic random failures of sync_large_checkpoints_mempool_mainnet, found on QEDIT CI.
+        run: cargo nextest run --profile all-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all --retries 3
         env:
           TEST_LARGE_CHECKPOINTS: 1
 

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -97,8 +97,7 @@ jobs:
           echo "PROPTEST_MAX_SHRINK_ITERS=1024" >> $GITHUB_ENV
 
       - name: Run unit tests
-        # TODO: Remove retries after investigating periodic random failures of sync_large_checkpoints_mempool_mainnet, found on QEDIT CI.
-        run: cargo nextest run --profile all-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all --retries 3
+        run: cargo nextest run --profile all-tests --locked --release --features "${{ matrix.features }}" --run-ignored=all
         env:
           TEST_LARGE_CHECKPOINTS: 1
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.89.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.94.0"


### PR DESCRIPTION
This fixes CI issues found while syncing upstream Zebra ZSA changes, and improves the fork’s basic CI by using `cargo nextest`.

Changes:

* harden basic CI for zizmor by pinning checkout, disabling persisted credentials, and using read-only repository permissions;
* align CI toolchain and tool versions with the upstream v4.2.0 baseline;
* run upstream workflows for PRs targeting `zsa-support`;
* use `cargo nextest` for normal Rust tests in `ci-basic.yml`;
* run doctests explicitly with `cargo test --doc`;
* centralize retry policy in `.config/nextest.toml`;
* retry only confirmed periodic random failures instead of using broad CI-level retries.
