### PR TITLE
Use ExpectedTranscriptError in Orchard ZSA workflow block tests

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,6 +2,9 @@ name: Basic checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,10 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -35,6 +41,7 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
+
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -47,16 +54,44 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run tests
+      - name: Run non-network tests
+        env:
+          SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
+
+      - name: Run network-sensitive tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "network-sensitive tests attempt ${attempt}"
+
+            timeout --preserve-status 45m bash -c '
+              set -euo pipefail
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
+            ' && exit 0
+
+            status=$?
+            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
+
       - name: Run format check
         run: cargo fmt -- --check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
+
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,6 +2,9 @@ name: Basic checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,10 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -35,6 +41,7 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
+
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -47,16 +54,72 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run tests
+      - name: Run non-network tests
+        env:
+          SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
+
+      # Build the network-sensitive test binaries outside the retry loops so
+      # compile failures fail once instead of being retried, and retry
+      # attempts below contain only test runtime.
+      - name: Build network-sensitive tests
+        run: |
+          cargo test -p zebra-network --lib --verbose --locked --no-run
+          cargo test -p zebrad --test acceptance --verbose --locked --no-run
+
+      # The two network-sensitive suites are retried independently so a flaky
+      # failure in one does not re-run the other. Per-attempt timeouts are
+      # sized from measured serial test runtimes (~15m and ~19m) plus headroom.
+      - name: Run zebra-network tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "zebra-network tests attempt ${attempt}"
+
+            timeout --preserve-status 25m \
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1 \
+              && exit 0
+
+            status=$?
+            echo "zebra-network tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
+      - name: Run zebrad acceptance tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "zebrad acceptance tests attempt ${attempt}"
+
+            timeout --preserve-status 30m \
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1 \
+              && exit 0
+
+            status=$?
+            echo "zebrad acceptance tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
+
       - name: Run format check
         run: cargo fmt -- --check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
+
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,9 +2,6 @@ name: Basic checks
 
 on: [push]
 
-permissions:
-  contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,10 +19,7 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
+      - uses: actions/checkout@v4
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -41,7 +35,6 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
-
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -54,44 +47,16 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run non-network tests
-        env:
-          SKIP_NETWORK_TESTS: "1"
+      - name: Run tests
         run: timeout --preserve-status 1h cargo test --verbose --locked
-
-      - name: Run network-sensitive tests
-        run: |
-          for attempt in 1 2 3; do
-            echo "network-sensitive tests attempt ${attempt}"
-
-            timeout --preserve-status 45m bash -c '
-              set -euo pipefail
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
-            ' && exit 0
-
-            status=$?
-            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
-
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
-
       - name: Run format check
         run: cargo fmt -- --check
-
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
-
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
-
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -176,25 +176,21 @@ fn create_transcript_data<'a, I: IntoIterator<Item = &'a OrchardWorkflowBlock>>(
         |OrchardWorkflowBlock {
              height: _,
              bytes,
-             is_valid,
+             expected_result,
          }| {
             (
                 Arc::new(Block::zcash_deserialize(&bytes[..]).expect("block should deserialize")),
-                *is_valid,
+                expected_result.clone(),
             )
         },
     );
 
-    std::iter::once((regtest_genesis_block(), true))
+    std::iter::once((regtest_genesis_block(), Ok(())))
         .chain(workflow_blocks)
-        .map(|(block, is_valid)| {
+        .map(|(block, expected_result)| {
             (
                 Request::Commit(block.clone()),
-                if is_valid {
-                    Ok(block.hash())
-                } else {
-                    Err(ExpectedTranscriptError::Any)
-                },
+                expected_result.map(|_| block.hash()),
             )
         })
 }

--- a/zebra-state/src/service/check/tests/issuance.rs
+++ b/zebra-state/src/service/check/tests/issuance.rs
@@ -59,7 +59,7 @@ fn check_burns_and_issuance() {
     for OrchardWorkflowBlock {
         height,
         bytes,
-        is_valid,
+        expected_result,
     } in ORCHARD_ZSA_WORKFLOW_BLOCKS.iter()
     {
         let block =
@@ -83,7 +83,7 @@ fn check_burns_and_issuance() {
         let commit_result =
             validate_and_commit_non_finalized(&finalized_state.db, &mut non_finalized_state, block);
 
-        if !is_valid {
+        if expected_result.is_err() {
             assert!(
                 issued_asset_changes_result.is_err() || commit_result.is_err(),
                 "invalid workflow block at height {height} should fail issued-asset validation or commit"

--- a/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
+++ b/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
@@ -5,14 +5,16 @@
 use hex::FromHex;
 use lazy_static::lazy_static;
 
+use crate::transcript::ExpectedTranscriptError;
+
 /// Represents a serialized block and its validity status.
 pub struct OrchardWorkflowBlock {
     /// Block height.
     pub height: u32,
     /// Serialized byte data of the block.
     pub bytes: &'static [u8],
-    /// Indicates whether the block is valid.
-    pub is_valid: bool,
+    /// Expected result of transcript validation for this block.
+    pub expected_result: Result<(), ExpectedTranscriptError>,
 }
 
 fn decode_bytes(hex: &str) -> Vec<u8> {
@@ -41,35 +43,35 @@ lazy_static! {
         OrchardWorkflowBlock {
             height: 1,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_1_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Transfer
         OrchardWorkflowBlock {
             height: 2,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_2_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Burn: 7, Burn: 2
         OrchardWorkflowBlock {
             height: 3,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_3_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Issue: finalize
         OrchardWorkflowBlock {
             height: 4,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_4_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Try to issue: 2000
         OrchardWorkflowBlock {
             height: 5,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_5_BYTES.as_slice(),
-            is_valid: false
+            expected_result: Err(ExpectedTranscriptError::Any)
         },
     ];
 }


### PR DESCRIPTION
This PR replaces the `is_valid: bool` field in `OrchardWorkflowBlock` with an explicit `Result<(), ExpectedTranscriptError>` as discussed in issue #116.

The original test gap was that `is_valid: false` only checked that block 5 failed, but did not check why it failed. Ideally, this test should assert that block 5 is rejected specifically because it tries to issue more assets after issuance was finalized.

I tried to make the workflow vector check that exact error, but the current transcript test API only supports `ExpectedTranscriptError::Any` and `ExpectedTranscriptError::Exact(...)`. For this rejection path, there is no specific error currently exposed through the transcript checker that can be matched here, so block 5 still uses `Err(ExpectedTranscriptError::Any)`.

So this PR does not fully add the semantic “post-finalization issuance” check yet, but it does remove the boolean validity flag and changes the vector format to use the typed transcript expected-result API. This makes the test data clearer and leaves the code ready for a stricter expected error once the transcript checker can expose one.
