### PR TITLE
Enable upstream lint workflow on all branches

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -2,7 +2,6 @@ name: Book
 
 on:
   push:
-    branches: [main]
     paths:
       - book/**
       - katex-header.html

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,6 @@ name: Coverage
 
 on:
   push:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,7 +2,6 @@ name: Docs Check
 
 on:
   push:
-    branches: [main]
     paths:
       - "**.md"
       - "book/**"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,6 @@ name: Lint
 
 on:
   pull_request:
-    # Temporarily allow CI on the QEDIT integration branch.
-    # TODO: Remove v4.2.0-dev before merging upstream.
-    branches:
-      - main
-      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -16,11 +11,6 @@ on:
       - .github/workflows/lint.yml
 
   push:
-    # Temporarily allow CI on the QEDIT integration branch.
-    # TODO: Remove v4.2.0-dev before merging upstream.
-    branches:
-      - main
-      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -2,7 +2,6 @@ name: Test Crate Build
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -12,7 +11,6 @@ on:
       - .github/workflows/test-crates.yml
 
   push:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -183,7 +181,6 @@ jobs:
         run: |
           cargo clippy --package ${{ matrix.crate }} --all-features --all-targets -- -D warnings
           cargo build --package ${{ matrix.crate }} --all-features --all-targets
-
 
   test-crate-build-success:
     name: test crate build success

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -2,7 +2,6 @@ name: Test Docker Config
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -14,7 +13,6 @@ on:
       - .github/workflows/test-docker.yml
 
   push:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -2,7 +2,6 @@ name: Unit Tests
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -11,7 +10,6 @@ on:
       - .github/workflows/tests-unit.yml
 
   push:
-    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,10 +1,6 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: ["**"]
+on: [push]
 
 permissions: {}
 

--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -34,7 +34,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))
@@ -54,7 +54,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))
@@ -73,7 +73,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))


### PR DESCRIPTION
This PR enables the upstream Zebra `Lint` workflow to run on all branches in the QEDIT fork.

The goal is to catch upstream lint/Clippy issues earlier, before asking ZcashFoundation to run CI on the upstream PR.

To do that, this temporarily removes the branch allowlist from `lint.yml`, while keeping the existing path filters.