### PR TITLE
ci: skip trusted_chain_sync_handles_forks_correctly test

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -48,7 +48,12 @@ jobs:
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
       - name: Run tests
-        run: timeout --preserve-status 1h cargo test --verbose --locked
+        run: |
+          # FIXME: Restore the full test run later.
+          # Temporarily skip this acceptance test in QEDIT CI because it starts a Mainnet zebrad
+          # and can be flaky due to external network/Mainnet conditions.
+          timeout --preserve-status 1h cargo test --verbose --locked -- \
+            --skip trusted_chain_sync_handles_forks_correctly
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
       - name: Run format check


### PR DESCRIPTION
This PR updates QEDIT's CI script (`ci-basic.yml`) to skip the flaky `trusted_chain_sync_handles_forks_correctly` acceptance test for now.

The test starts a Mainnet `zebrad` and can fail due to external network/Mainnet conditions. It currently blocks unrelated work on `zsa1`.

The rest of the test suite still runs as before.
