### PR TITLE
use nextest per-test retries for network-sensitive tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,6 +32,29 @@ filter = "not test(=trusted_chain_sync_handles_forks_correctly) and not test(=de
 failure-output = "immediate"
 default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet)"
 
+# --- Basic checks profile ---
+# Used by the fork's Basic checks workflow (.github/workflows/ci-basic.yml).
+#
+# Network-sensitive tests (zebra-network unit tests and the zebrad acceptance
+# suite) are flaky on shared CI runners, so they run serially and get per-test
+# retries. Everything else runs in parallel without retries, so deterministic
+# failures fail fast instead of re-running a whole test group.
+
+# Network-sensitive tests bind real sockets and launch full nodes, so they
+# must not run concurrently with each other.
+[test-groups.network]
+max-threads = 1
+
+[profile.ci-basic]
+failure-output = "immediate"
+
+[[profile.ci-basic.overrides]]
+filter = '(package(zebra-network) & kind(lib)) | binary_id(zebrad::acceptance)'
+# 2 retries = up to 3 attempts per test, matching the previous workflow-level
+# retry loop, with the same 30s pause between attempts.
+retries = { backoff = "fixed", count = 2, delay = "30s" }
+test-group = "network"
+
 # --- Individual Test Profiles ---
 
 [profile.check-no-git-dependencies]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -35,10 +35,10 @@ default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced
 # --- Basic checks profile ---
 # Used by the fork's Basic checks workflow (.github/workflows/ci-basic.yml).
 #
-# Network-sensitive tests (zebra-network unit tests and the zebrad acceptance
-# suite) are flaky on shared CI runners, so they run serially and get per-test
-# retries. Everything else runs in parallel without retries, so deterministic
-# failures fail fast instead of re-running a whole test group.
+# Network-sensitive tests (zebra-network socket tests and the zebrad
+# acceptance suite) are flaky on shared CI runners, so they run serially and
+# get per-test retries. Everything else runs in parallel without retries, so
+# deterministic failures fail fast instead of re-running a whole test group.
 
 # Network-sensitive tests bind real sockets and launch full nodes, so they
 # must not run concurrently with each other.
@@ -47,9 +47,20 @@ max-threads = 1
 
 [profile.ci-basic]
 failure-output = "immediate"
+# List skipped tests in the final summary so accidental skips stay visible.
+final-status-level = "skip"
+# Keep going after a failure (up to 5) so one red run reports all failures.
+fail-fast = { max-fail = 5 }
+# Flag slow tests every 60s and kill them after 10 minutes, so a hung test is
+# named and (if network-sensitive) retried, instead of the workflow-level
+# timeout killing the whole run without identifying the culprit.
+slow-timeout = { period = "60s", terminate-after = 10 }
 
+# Only tests that actually touch the network: zebra-network's socket tests
+# live in the `peer_set::initialize` and `isolated` modules; the rest of its
+# lib tests are in-process and safe to run in parallel without retries.
 [[profile.ci-basic.overrides]]
-filter = '(package(zebra-network) & kind(lib)) | binary_id(zebrad::acceptance)'
+filter = '(package(zebra-network) & kind(lib) & (test(~peer_set::initialize) | test(~isolated))) | binary_id(zebrad::acceptance)'
 # 2 retries = up to 3 attempts per test, matching the previous workflow-level
 # retry loop, with the same 30s pause between attempts.
 retries = { backoff = "fixed", count = 2, delay = "30s" }

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2.81.3
+        with:
+          tool: cargo-nextest@0.9.137
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -54,31 +59,16 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run non-network tests
-        env:
-          SKIP_NETWORK_TESTS: "1"
-        run: timeout --preserve-status 1h cargo test --verbose --locked
+      # The ci-basic nextest profile (.config/nextest.toml) gives
+      # network-sensitive tests per-test retries and serializes them, so a
+      # flaky network test is retried on its own instead of re-running a
+      # whole test group, and deterministic failures fail fast.
+      - name: Run tests
+        run: timeout --preserve-status 90m cargo nextest run --workspace --locked --profile ci-basic
 
-      - name: Run network-sensitive tests
-        run: |
-          for attempt in 1 2 3; do
-            echo "network-sensitive tests attempt ${attempt}"
-
-            timeout --preserve-status 45m bash -c '
-              set -euo pipefail
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
-            ' && exit 0
-
-            status=$?
-            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
+      # nextest doesn't run doctests, so run them separately
+      - name: Run doc tests
+        run: timeout --preserve-status 30m cargo test --doc --workspace --locked
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -50,6 +50,15 @@ jobs:
         with:
           tool: cargo-nextest@0.9.137
 
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          # The nu7 legs build with different cfg flags (see the strip step
+          # below), so their build artifacts are not interchangeable.
+          key: nu7-${{ matrix.nu7 }}
+          # Tests can fail while the build itself succeeded; keep the cache.
+          cache-on-failure: true
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 


### PR DESCRIPTION
Replace the split cargo-test steps and workflow-level retry loop with a single 'cargo nextest run' using a new ci-basic profile:

- network-sensitive tests (zebra-network lib, zebrad acceptance) run serially via a test group and get per-test retries (3 attempts, 30s pause, matching the old loop)
- everything else runs in parallel with no retries, so deterministic failures fail fast instead of re-running a whole test group
- non-network tests in those targets no longer run twice
- doctests run in a separate step (nextest does not run them)

cargo-nextest is installed via taiki-e/install-action pinned by SHA, consistent with the existing checkout hardening.
