### PR TITLE
fix(ci): use regtest dockerfile for ECR push

### DIFF
--- a/.github/workflows/push-ecr.yaml
+++ b/.github/workflows/push-ecr.yaml
@@ -23,7 +23,7 @@ jobs:
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-      DOCKERFILE_PATH: docker/Dockerfile
+      DOCKERFILE_PATH: testnet-single-node-deploy/dockerfile
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
push-ecr.yaml was pointing at docker/Dockerfile (the upstream mainnet image) instead of testnet-single-node-deploy/dockerfile (the regtest image used by tx-tool). The ECS node was syncing mainnet from genesis, causing tx-tool to fail with exit code 101.