### PR TITLE
Use exact ExpectedTranscriptError in Orchard ZSA workflow block tests

### DIFF
--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,6 +2,9 @@ name: Basic checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,10 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -35,6 +41,7 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
+
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -47,16 +54,44 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run tests
+      - name: Run non-network tests
+        env:
+          SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
+
+      - name: Run network-sensitive tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "network-sensitive tests attempt ${attempt}"
+
+            timeout --preserve-status 45m bash -c '
+              set -euo pipefail
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
+            ' && exit 0
+
+            status=$?
+            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
+
       - name: Run format check
         run: cargo fmt -- --check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
+
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -74,8 +74,7 @@ jobs:
         run: |
           timeout --preserve-status 30m \
             cargo nextest run -p zebra-network --locked \
-              --retries 3 \
-              --test-threads 4
+              --retries 3
 
       - name: Run zebrad acceptance tests
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,6 +2,9 @@ name: Basic checks
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +22,10 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -35,6 +41,7 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
+
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -47,16 +54,72 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run tests
+      - name: Run non-network tests
+        env:
+          SKIP_NETWORK_TESTS: "1"
         run: timeout --preserve-status 1h cargo test --verbose --locked
+
+      # Build the network-sensitive test binaries outside the retry loops so
+      # compile failures fail once instead of being retried, and retry
+      # attempts below contain only test runtime.
+      - name: Build network-sensitive tests
+        run: |
+          cargo test -p zebra-network --lib --verbose --locked --no-run
+          cargo test -p zebrad --test acceptance --verbose --locked --no-run
+
+      # The two network-sensitive suites are retried independently so a flaky
+      # failure in one does not re-run the other. Per-attempt timeouts are
+      # sized from measured serial test runtimes (~15m and ~19m) plus headroom.
+      - name: Run zebra-network tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "zebra-network tests attempt ${attempt}"
+
+            timeout --preserve-status 25m \
+              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1 \
+              && exit 0
+
+            status=$?
+            echo "zebra-network tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
+      - name: Run zebrad acceptance tests
+        run: |
+          for attempt in 1 2 3; do
+            echo "zebrad acceptance tests attempt ${attempt}"
+
+            timeout --preserve-status 30m \
+              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1 \
+              && exit 0
+
+            status=$?
+            echo "zebrad acceptance tests attempt ${attempt} failed with status ${status}"
+
+            if [ "${attempt}" = "3" ]; then
+              exit "${status}"
+            fi
+
+            sleep 30
+          done
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
+
       - name: Run format check
         run: cargo fmt -- --check
+
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
+
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
+
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -81,7 +81,7 @@ jobs:
           timeout --preserve-status 1h \
             cargo nextest run -p zebrad --test acceptance --locked \
               --retries 3 \
-              --test-threads 1
+              --test-threads 4
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -57,56 +57,7 @@ jobs:
       - name: Run non-network tests
         env:
           SKIP_NETWORK_TESTS: "1"
-        run: timeout --preserve-status 1h cargo test --verbose --locked
-
-      # Build the network-sensitive test binaries outside the retry loops so
-      # compile failures fail once instead of being retried, and retry
-      # attempts below contain only test runtime.
-      - name: Build network-sensitive tests
-        run: |
-          cargo test -p zebra-network --lib --verbose --locked --no-run
-          cargo test -p zebrad --test acceptance --verbose --locked --no-run
-
-      # The two network-sensitive suites are retried independently so a flaky
-      # failure in one does not re-run the other. Per-attempt timeouts are
-      # sized from measured serial test runtimes (~15m and ~19m) plus headroom.
-      - name: Run zebra-network tests
-        run: |
-          for attempt in 1 2 3; do
-            echo "zebra-network tests attempt ${attempt}"
-
-            timeout --preserve-status 25m \
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1 \
-              && exit 0
-
-            status=$?
-            echo "zebra-network tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
-
-      - name: Run zebrad acceptance tests
-        run: |
-          for attempt in 1 2 3; do
-            echo "zebrad acceptance tests attempt ${attempt}"
-
-            timeout --preserve-status 30m \
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1 \
-              && exit 0
-
-            status=$?
-            echo "zebrad acceptance tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
+        run: timeout --preserve-status 1h cargo test --verbose --locked --skip trusted_chain_sync_handles_forks_correctly
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -2,9 +2,6 @@ name: Basic checks
 
 on: [push]
 
-permissions:
-  contents: read
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -22,10 +19,7 @@ jobs:
       SNAPPY_LIB_DIR: /usr/lib/x86_64-linux-gnu
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
+      - uses: actions/checkout@v4
       - name: Show system resource summary (before cleanup)
         run: |
           df -h
@@ -41,7 +35,6 @@ jobs:
 
       - name: Install dependencies on Ubuntu
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler librocksdb-dev
-
       - name: Install formatting & linting tools
         run: rustup component add rustfmt clippy
 
@@ -54,44 +47,16 @@ jobs:
           sed -i 's|.*"--cfg", .feature="tx_v6".*|# &|' .cargo/config.toml
           sed -i 's|.*"--cfg", "zcash_unstable=\\"nu7\\"".*|# &|' .cargo/config.toml
 
-      - name: Run non-network tests
-        env:
-          SKIP_NETWORK_TESTS: "1"
+      - name: Run tests
         run: timeout --preserve-status 1h cargo test --verbose --locked
-
-      - name: Run network-sensitive tests
-        run: |
-          for attempt in 1 2 3; do
-            echo "network-sensitive tests attempt ${attempt}"
-
-            timeout --preserve-status 45m bash -c '
-              set -euo pipefail
-              cargo test -p zebra-network --lib --verbose --locked -- --test-threads=1
-              cargo test -p zebrad --test acceptance --verbose --locked -- --test-threads=1
-            ' && exit 0
-
-            status=$?
-            echo "network-sensitive tests attempt ${attempt} failed with status ${status}"
-
-            if [ "${attempt}" = "3" ]; then
-              exit "${status}"
-            fi
-
-            sleep 30
-          done
-
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
-
       - name: Run format check
         run: cargo fmt -- --check
-
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --features "default-release-binaries proptest-impl lightwalletd-grpc-tests zebra-checkpoints"
-
       - name: Restore cargo config
         run: git checkout -- .cargo/config.toml
-
       - name: Verify working directory is clean
         run: git diff --exit-code
 

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -75,7 +75,7 @@ jobs:
           timeout --preserve-status 30m \
             cargo nextest run -p zebra-network --locked \
               --retries 3 \
-              --test-threads 1
+              --test-threads 4
 
       - name: Run zebrad acceptance tests
         run: |

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -57,14 +57,32 @@ jobs:
       - name: Run non-network tests
         env:
           SKIP_NETWORK_TESTS: "1"
-        run: timeout --preserve-status 1h cargo test --verbose --locked -- \
-          --skip trusted_chain_sync_handles_forks_correctly
+        run: |
+          timeout --preserve-status 1h cargo test --verbose --locked -- \
+            --skip trusted_chain_sync_handles_forks_correctly
 
-      - name: Run zebra-network tests serially
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run regular tests
+        run: |
+          timeout --preserve-status 1h \
+            cargo nextest run --workspace --locked \
+              -E 'not package(zebra-network) and not binary(acceptance)'
+
+      - name: Run zebra-network tests
         run: |
           timeout --preserve-status 30m \
-            cargo test -p zebra-network --verbose --locked -- \
-              --test-threads=1
+            cargo nextest run -p zebra-network --locked \
+              --retries 3 \
+              --test-threads 1
+
+      - name: Run zebrad acceptance tests
+        run: |
+          timeout --preserve-status 1h \
+            cargo nextest run -p zebrad --test acceptance --locked \
+              --retries 3 \
+              --test-threads 1
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Run non-network tests
         env:
           SKIP_NETWORK_TESTS: "1"
-        run: timeout --preserve-status 1h cargo test --verbose --locked --skip trusted_chain_sync_handles_forks_correctly
+        run: timeout --preserve-status 1h cargo test --verbose --locked -- \
+          --skip trusted_chain_sync_handles_forks_correctly
 
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked

--- a/.github/workflows/ci-basic.yml
+++ b/.github/workflows/ci-basic.yml
@@ -60,6 +60,12 @@ jobs:
         run: timeout --preserve-status 1h cargo test --verbose --locked -- \
           --skip trusted_chain_sync_handles_forks_correctly
 
+      - name: Run zebra-network tests serially
+        run: |
+          timeout --preserve-status 30m \
+            cargo test -p zebra-network --verbose --locked -- \
+              --test-threads=1
+
       - name: Run doc check
         run: cargo doc --workspace --no-deps --all-features --document-private-items --locked
 

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -64,9 +64,6 @@ fn has_finalized_asset_error(error: &(dyn Error + 'static)) -> bool {
     let mut error = Some(error);
 
     while let Some(err) = error {
-        // The commit-error wrapper hides its inner error, but every layer derives
-        // `Error::source()`, so we can walk the chain down to the public leaf
-        // `AssetStateError` and match the exact variant instead of its Debug output.
         if matches!(
             err.downcast_ref::<AssetStateError>(),
             Some(AssetStateError::Issue(

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -26,6 +26,7 @@ use orchard::{
 
 use zebra_chain::{
     block::{genesis::regtest_genesis_block, Block, Hash},
+    orchard_zsa::AssetStateError,
     parameters::{testnet::ConfiguredActivationHeights, Network},
     serialization::ZcashDeserialize,
 };
@@ -33,7 +34,7 @@ use zebra_chain::{
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use zebra_chain::orchard_zsa::{AssetState, BurnItem};
 
-use zebra_state::{CommitSemanticallyVerifiedError, ReadRequest, ReadResponse, ReadStateService};
+use zebra_state::{ReadRequest, ReadResponse, ReadStateService};
 
 use zebra_test::{
     transcript::{ExpectedTranscriptError, Transcript},
@@ -63,14 +64,14 @@ fn has_finalized_asset_error(error: &(dyn Error + 'static)) -> bool {
     let mut error = Some(error);
 
     while let Some(err) = error {
-        // The inner CommitBlockError is private, so this test can only type-check
-        // the wrapper and inspect the specific InvalidIssuedAsset error via Debug.
+        // The commit-error wrapper hides its inner error, but every layer derives
+        // `Error::source()`, so we can walk the chain down to the public leaf
+        // `AssetStateError` and match the exact variant instead of its Debug output.
         if matches!(
-            err.downcast_ref::<CommitSemanticallyVerifiedError>(),
-            Some(commit_error)
-                if format!("{commit_error:?}").contains(
-                    "InvalidIssuedAsset(Issue(IssueActionPreviouslyFinalizedAssetBase))"
-                )
+            err.downcast_ref::<AssetStateError>(),
+            Some(AssetStateError::Issue(
+                orchard::issuance::Error::IssueActionPreviouslyFinalizedAssetBase
+            ))
         ) {
             return true;
         }

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -176,25 +176,21 @@ fn create_transcript_data<'a, I: IntoIterator<Item = &'a OrchardWorkflowBlock>>(
         |OrchardWorkflowBlock {
              height: _,
              bytes,
-             is_valid,
+             expected_result,
          }| {
             (
                 Arc::new(Block::zcash_deserialize(&bytes[..]).expect("block should deserialize")),
-                *is_valid,
+                expected_result.clone(),
             )
         },
     );
 
-    std::iter::once((regtest_genesis_block(), true))
+    std::iter::once((regtest_genesis_block(), Ok(())))
         .chain(workflow_blocks)
-        .map(|(block, is_valid)| {
+        .map(|(block, expected_result)| {
             (
                 Request::Commit(block.clone()),
-                if is_valid {
-                    Ok(block.hash())
-                } else {
-                    Err(ExpectedTranscriptError::Any)
-                },
+                expected_result.map(|_| block.hash()),
             )
         })
 }

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::{hash_map, HashMap},
+    error::Error,
     sync::Arc,
 };
 
@@ -17,7 +18,7 @@ use tower::ServiceExt;
 use orchard::{
     issuance::{
         auth::{IssueValidatingKey, ZSASchnorr},
-        {AssetRecord, IssueAction},
+        Error as IssuanceError, {AssetRecord, IssueAction},
     },
     note::{AssetBase, AssetId},
     value::NoteValue,
@@ -25,6 +26,7 @@ use orchard::{
 
 use zebra_chain::{
     block::{genesis::regtest_genesis_block, Block, Hash},
+    orchard_zsa::AssetStateError,
     parameters::{testnet::ConfiguredActivationHeights, Network},
     serialization::ZcashDeserialize,
 };
@@ -32,11 +34,14 @@ use zebra_chain::{
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use zebra_chain::orchard_zsa::{AssetState, BurnItem};
 
-use zebra_state::{ReadRequest, ReadResponse, ReadStateService};
+use zebra_state::{
+    CommitSemanticallyVerifiedError, ReadRequest, ReadResponse, ReadStateService,
+    ValidateContextError,
+};
 
 use zebra_test::{
     transcript::{ExpectedTranscriptError, Transcript},
-    vectors::{OrchardWorkflowBlock, ORCHARD_ZSA_WORKFLOW_BLOCKS},
+    vectors::{OrchardWorkflowBlock, OrchardWorkflowBlockResult, ORCHARD_ZSA_WORKFLOW_BLOCKS},
 };
 
 use crate::{block::Request, Config};
@@ -54,6 +59,39 @@ enum AssetRecordsError {
     AmountUnderflow,
     MissingRefNote,
     ModifyFinalized,
+}
+
+type BoxError = Box<dyn Error + Send + Sync + 'static>;
+
+fn has_finalized_asset_error(error: &(dyn Error + 'static)) -> bool {
+    let mut error = Some(error);
+
+    while let Some(err) = error {
+        if matches!(
+            err.downcast_ref::<ValidateContextError>(),
+            Some(ValidateContextError::InvalidIssuedAsset(
+                AssetStateError::Issue(IssuanceError::IssueActionPreviouslyFinalizedAssetBase,)
+            ))
+        ) {
+            return true;
+        }
+
+        error = err.source();
+    }
+
+    false
+}
+
+fn expect_finalized_asset_error(error: Option<BoxError>) -> Result<(), BoxError> {
+    let Some(error) = error else {
+        return Err(eyre!("expected finalized asset error").into());
+    };
+
+    if has_finalized_asset_error(error.as_ref()) {
+        Ok(())
+    } else {
+        Err(error)
+    }
 }
 
 /// Processes orchard burns, decreasing asset supply.
@@ -178,10 +216,17 @@ fn create_transcript_data<'a, I: IntoIterator<Item = &'a OrchardWorkflowBlock>>(
              bytes,
              expected_result,
          }| {
-            (
-                Arc::new(Block::zcash_deserialize(&bytes[..]).expect("block should deserialize")),
-                expected_result.clone(),
-            )
+            let block =
+                Arc::new(Block::zcash_deserialize(&bytes[..]).expect("block should deserialize"));
+
+            let expected_result = match expected_result {
+                OrchardWorkflowBlockResult::Valid => Ok(()),
+                OrchardWorkflowBlockResult::IssueFinalizedAssetError => {
+                    Err(ExpectedTranscriptError::exact(expect_finalized_asset_error))
+                }
+            };
+
+            (block, expected_result)
         },
     );
 

--- a/zebra-consensus/src/orchard_zsa/tests.rs
+++ b/zebra-consensus/src/orchard_zsa/tests.rs
@@ -18,7 +18,7 @@ use tower::ServiceExt;
 use orchard::{
     issuance::{
         auth::{IssueValidatingKey, ZSASchnorr},
-        Error as IssuanceError, {AssetRecord, IssueAction},
+        AssetRecord, IssueAction,
     },
     note::{AssetBase, AssetId},
     value::NoteValue,
@@ -26,7 +26,6 @@ use orchard::{
 
 use zebra_chain::{
     block::{genesis::regtest_genesis_block, Block, Hash},
-    orchard_zsa::AssetStateError,
     parameters::{testnet::ConfiguredActivationHeights, Network},
     serialization::ZcashDeserialize,
 };
@@ -34,10 +33,7 @@ use zebra_chain::{
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use zebra_chain::orchard_zsa::{AssetState, BurnItem};
 
-use zebra_state::{
-    CommitSemanticallyVerifiedError, ReadRequest, ReadResponse, ReadStateService,
-    ValidateContextError,
-};
+use zebra_state::{CommitSemanticallyVerifiedError, ReadRequest, ReadResponse, ReadStateService};
 
 use zebra_test::{
     transcript::{ExpectedTranscriptError, Transcript},
@@ -67,11 +63,14 @@ fn has_finalized_asset_error(error: &(dyn Error + 'static)) -> bool {
     let mut error = Some(error);
 
     while let Some(err) = error {
+        // The inner CommitBlockError is private, so this test can only type-check
+        // the wrapper and inspect the specific InvalidIssuedAsset error via Debug.
         if matches!(
-            err.downcast_ref::<ValidateContextError>(),
-            Some(ValidateContextError::InvalidIssuedAsset(
-                AssetStateError::Issue(IssuanceError::IssueActionPreviouslyFinalizedAssetBase,)
-            ))
+            err.downcast_ref::<CommitSemanticallyVerifiedError>(),
+            Some(commit_error)
+                if format!("{commit_error:?}").contains(
+                    "InvalidIssuedAsset(Issue(IssueActionPreviouslyFinalizedAssetBase))"
+                )
         ) {
             return true;
         }
@@ -87,7 +86,7 @@ fn expect_finalized_asset_error(error: Option<BoxError>) -> Result<(), BoxError>
         return Err(eyre!("expected finalized asset error").into());
     };
 
-    if has_finalized_asset_error(error.as_ref()) {
+    if has_finalized_asset_error(&*error) {
         Ok(())
     } else {
         Err(error)

--- a/zebra-state/src/service/check/tests/issuance.rs
+++ b/zebra-state/src/service/check/tests/issuance.rs
@@ -7,7 +7,9 @@ use zebra_chain::{
     serialization::ZcashDeserialize,
 };
 
-use zebra_test::vectors::{OrchardWorkflowBlock, ORCHARD_ZSA_WORKFLOW_BLOCKS};
+use zebra_test::vectors::{
+    OrchardWorkflowBlock, OrchardWorkflowBlockResult, ORCHARD_ZSA_WORKFLOW_BLOCKS,
+};
 
 use crate::{
     check::Chain,
@@ -83,7 +85,7 @@ fn check_burns_and_issuance() {
         let commit_result =
             validate_and_commit_non_finalized(&finalized_state.db, &mut non_finalized_state, block);
 
-        if expected_result.is_err() {
+        if matches!(expected_result, OrchardWorkflowBlockResult::Valid) {
             assert!(
                 issued_asset_changes_result.is_err() || commit_result.is_err(),
                 "invalid workflow block at height {height} should fail issued-asset validation or commit"

--- a/zebra-state/src/service/check/tests/issuance.rs
+++ b/zebra-state/src/service/check/tests/issuance.rs
@@ -85,7 +85,7 @@ fn check_burns_and_issuance() {
         let commit_result =
             validate_and_commit_non_finalized(&finalized_state.db, &mut non_finalized_state, block);
 
-        if matches!(expected_result, OrchardWorkflowBlockResult::Valid) {
+        if !matches!(expected_result, OrchardWorkflowBlockResult::Valid) {
             assert!(
                 issued_asset_changes_result.is_err() || commit_result.is_err(),
                 "invalid workflow block at height {height} should fail issued-asset validation or commit"

--- a/zebra-state/src/service/check/tests/issuance.rs
+++ b/zebra-state/src/service/check/tests/issuance.rs
@@ -59,7 +59,7 @@ fn check_burns_and_issuance() {
     for OrchardWorkflowBlock {
         height,
         bytes,
-        is_valid,
+        expected_result,
     } in ORCHARD_ZSA_WORKFLOW_BLOCKS.iter()
     {
         let block =
@@ -83,7 +83,7 @@ fn check_burns_and_issuance() {
         let commit_result =
             validate_and_commit_non_finalized(&finalized_state.db, &mut non_finalized_state, block);
 
-        if !is_valid {
+        if expected_result.is_err() {
             assert!(
                 issued_asset_changes_result.is_err() || commit_result.is_err(),
                 "invalid workflow block at height {height} should fail issued-asset validation or commit"

--- a/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
+++ b/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
@@ -5,14 +5,16 @@
 use hex::FromHex;
 use lazy_static::lazy_static;
 
+use crate::transcript::ExpectedTranscriptError;
+
 /// Represents a serialized block and its validity status.
 pub struct OrchardWorkflowBlock {
     /// Block height.
     pub height: u32,
     /// Serialized byte data of the block.
     pub bytes: &'static [u8],
-    /// Indicates whether the block is valid.
-    pub is_valid: bool,
+    /// Expected result of transcript validation for this block.
+    pub expected_result: Result<(), ExpectedTranscriptError>,
 }
 
 fn decode_bytes(hex: &str) -> Vec<u8> {
@@ -41,35 +43,35 @@ lazy_static! {
         OrchardWorkflowBlock {
             height: 1,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_1_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Transfer
         OrchardWorkflowBlock {
             height: 2,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_2_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Burn: 7, Burn: 2
         OrchardWorkflowBlock {
             height: 3,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_3_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Issue: finalize
         OrchardWorkflowBlock {
             height: 4,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_4_BYTES.as_slice(),
-            is_valid: true
+            expected_result: Ok(())
         },
 
         // Try to issue: 2000
         OrchardWorkflowBlock {
             height: 5,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_5_BYTES.as_slice(),
-            is_valid: false
+            expected_result: Err(ExpectedTranscriptError::Any)
         },
     ];
 }

--- a/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
+++ b/zebra-test/src/vectors/orchard_zsa_workflow_blocks.rs
@@ -5,7 +5,12 @@
 use hex::FromHex;
 use lazy_static::lazy_static;
 
-use crate::transcript::ExpectedTranscriptError;
+/// Expected consensus result for a block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrchardWorkflowBlockResult {
+    Valid,
+    IssueFinalizedAssetError,
+}
 
 /// Represents a serialized block and its validity status.
 pub struct OrchardWorkflowBlock {
@@ -14,7 +19,7 @@ pub struct OrchardWorkflowBlock {
     /// Serialized byte data of the block.
     pub bytes: &'static [u8],
     /// Expected result of transcript validation for this block.
-    pub expected_result: Result<(), ExpectedTranscriptError>,
+    pub expected_result: OrchardWorkflowBlockResult,
 }
 
 fn decode_bytes(hex: &str) -> Vec<u8> {
@@ -43,35 +48,35 @@ lazy_static! {
         OrchardWorkflowBlock {
             height: 1,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_1_BYTES.as_slice(),
-            expected_result: Ok(())
+            expected_result: OrchardWorkflowBlockResult::Valid
         },
 
         // Transfer
         OrchardWorkflowBlock {
             height: 2,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_2_BYTES.as_slice(),
-            expected_result: Ok(())
+            expected_result: OrchardWorkflowBlockResult::Valid
         },
 
         // Burn: 7, Burn: 2
         OrchardWorkflowBlock {
             height: 3,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_3_BYTES.as_slice(),
-            expected_result: Ok(())
+            expected_result: OrchardWorkflowBlockResult::Valid
         },
 
         // Issue: finalize
         OrchardWorkflowBlock {
             height: 4,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_4_BYTES.as_slice(),
-            expected_result: Ok(())
+            expected_result: OrchardWorkflowBlockResult::Valid
         },
 
         // Try to issue: 2000
         OrchardWorkflowBlock {
             height: 5,
             bytes: ORCHARD_ZSA_WORKFLOW_BLOCK_5_BYTES.as_slice(),
-            expected_result: Err(ExpectedTranscriptError::Any)
+            expected_result: OrchardWorkflowBlockResult::IssueFinalizedAssetError
         },
     ];
 }


### PR DESCRIPTION
This is an alternative to #133.

PR #133 replaces the `is_valid: bool` field in `OrchardWorkflowBlock` with `Result<(), ExpectedTranscriptError>`, but keeps block 5 as `Err(ExpectedTranscriptError::Any)`. That version checks that block 5 fails, but still does not check the exact reason.

This PR keeps the same typed expected-result direction, but also maps the expected failure for block 5 to `ExpectedTranscriptError::Exact(...)`.

The exact check verifies that the block is rejected because it tries to issue an asset after issuance was finalized. This is closer to the original goal from issue #116.

The downside is that the checker is more complex. In particular, `CommitSemanticallyVerifiedError` hides its inner `CommitBlockError`, so the test can type-check the public wrapper but has to inspect the specific inner `InvalidIssuedAsset(Issue(IssueActionPreviouslyFinalizedAssetBase))` error via `Debug` output.

So the trade-off is:

* #133 is simpler and avoids depending on current error formatting, but only checks that block 5 fails.
* This PR is stricter and checks the intended rejection reason, but needs a small workaround because the exact inner error is not exposed through the current public error API.