### PR TITLE
Retry two more flaky peer-related nextest cases

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -138,5 +138,7 @@ default-filter = 'package(zebrad) and test(=fully_synced_rpc_z_getsubtreesbyinde
 [[profile.default.overrides]]
 filter = '''
 test(=sync_large_checkpoints_mempool_mainnet)
+or test(=get_peer_info)
+or test(=activate_mempool_mainnet)
 '''
 retries = 3


### PR DESCRIPTION
Adds `get_peer_info` and `activate_mempool_mainnet` to the temporary nextest retry override. Both tests occasionally fail in CI due to peer/network connection issues.
