### PR TITLE
Improve security of ECS and fix ECR output references

### DIFF
--- a/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/main.tf
+++ b/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/main.tf
@@ -76,6 +76,9 @@ resource "aws_ecs_service" "service" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      task_definition
+    ]
   }
 
 }
@@ -90,6 +93,7 @@ resource "aws_ecs_task_definition" "task" {
   memory                   = var.task_memory
   execution_role_arn       = aws_iam_role.ecs_execution_role.arn
   task_role_arn            = aws_iam_role.ecs_execution_role.arn
+  tags                     = {}
 
   ephemeral_storage {
     size_in_gib = 70 # Adjust this size according to your needs
@@ -101,20 +105,22 @@ resource "aws_ecs_task_definition" "task" {
       name = "persistent-volume"
 
       efs_volume_configuration {
-        file_system_id     = aws_efs_file_system.persistent_efs[0].id
-        root_directory     = "/"
-        transit_encryption = "ENABLED"
+        file_system_id          = aws_efs_file_system.persistent_efs[0].id
+        root_directory          = "/"
+        transit_encryption      = "ENABLED"
+        transit_encryption_port = 0
       }
     }
   }
 
   container_definitions = jsonencode([
     {
-      name      = "${var.name}-container"
-      image     = var.image
-      cpu       = var.task_cpu
-      memory    = var.task_memory
-      essential = true
+      name        = "${var.name}-container"
+      image       = var.image
+      cpu         = var.task_cpu
+      memory      = var.task_memory
+      essential   = true
+      environment = []
       ulimits = [{
         name      = "nofile"
         softLimit = 1000000
@@ -130,10 +136,7 @@ resource "aws_ecs_task_definition" "task" {
         }
       } : null
       healthCheck = {
-        command = [
-          "CMD-SHELL",
-          "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"getinfo\",\"params\":[],\"id\":1}' http://localhost:18232/ || exit 1"
-        ]
+        command     = var.container_health_check_command
         interval    = 15  # Time between health checks in seconds
         timeout     = 10  # Time before a health check is considered failed
         retries     = 5   # Number of consecutive failures before marking as unhealthy
@@ -145,6 +148,8 @@ resource "aws_ecs_task_definition" "task" {
         containerPath = "/persistent" # Mount point in the container
         readOnly      = false
       }] : []
+      systemControls = []
+      volumesFrom    = []
 
     }
     ]
@@ -261,11 +266,27 @@ resource "aws_security_group" "sg" {
   description = "manage rules for ${var.name} ecs service"
   vpc_id      = var.vpc_id
 
-  ingress {
-    from_port   = 18232
-    to_port     = 18232
-    protocol    = "tcp"
-    cidr_blocks = local.load_balancer_subnet_cidr_blocks
+  dynamic "ingress" {
+    for_each = var.allow_all_ecs_ingress ? [1] : []
+
+    content {
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.allow_all_ecs_ingress ? [] : [1]
+
+    content {
+      from_port   = 18232
+      to_port     = 18232
+      protocol    = "tcp"
+      cidr_blocks = local.load_balancer_subnet_cidr_blocks
+    }
   }
 
 
@@ -289,7 +310,7 @@ resource "random_string" "random" {
 resource "aws_efs_file_system" "persistent_efs" {
   count          = var.enable_persistent ? 1 : 0
   creation_token = "${var.environment}-${var.region}-${var.name}-${random_string.random.result}"
-  encrypted      = true
+  encrypted      = var.efs_encrypted
 
   lifecycle_policy {
     transition_to_ia = "AFTER_60_DAYS"
@@ -326,11 +347,49 @@ resource "aws_security_group" "efs_sg" {
   description = "Security group for EFS used by ${var.name}"
   vpc_id      = var.vpc_id
 
+  dynamic "ingress" {
+    for_each = var.allow_all_efs_ingress ? [1] : []
+
+    content {
+      from_port   = 2049
+      to_port     = 2049
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.allow_all_efs_ingress ? [] : [1]
+
+    content {
+      from_port       = 2049
+      to_port         = 2049
+      protocol        = "tcp"
+      security_groups = [aws_security_group.sg.id]
+    }
+  }
+}
+
+resource "aws_security_group" "lb_sg" {
+  count       = var.create_legacy_lb_security_group ? 1 : 0
+  name        = "${var.environment}-${var.name}-lb-security-group"
+  description = "Security group for load balancer"
+  vpc_id      = var.vpc_id
+
   ingress {
-    from_port       = 2049
-    to_port         = 2049
-    protocol        = "tcp"
-    security_groups = [aws_security_group.sg.id]
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 }
 

--- a/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/outputs.tf
+++ b/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/outputs.tf
@@ -7,11 +7,11 @@ output "lb-dns" {
 }
 
 output "domain_name" {
-  value = var.enable_domain ? "https://${aws_route53_record.lb_dns[0].name}" : ""
+  value       = var.enable_domain ? "https://${aws_route53_record.lb_dns[0].name}" : ""
   description = "The domain name"
 }
 
 output "certificate_arn" {
-  value = local.enable_tls ? [aws_acm_certificate.cert[0].arn] : []
+  value       = local.enable_tls ? [aws_acm_certificate.cert[0].arn] : []
   description = "The certificate used"
 }

--- a/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/variables.tf
+++ b/testnet-single-node-deploy/infra/terraform-aws-modules/ecs/variables.tf
@@ -28,23 +28,32 @@ variable "image" {
 
 variable "task_cpu" {
   default = 4096
-  type = number
+  type    = number
 }
 
 variable "task_memory" {
   default = 16384
-  type = number
+  type    = number
+}
+
+variable "container_health_check_command" {
+  description = "Container health check command to keep task definition changes explicit"
+  type        = list(string)
+  default = [
+    "CMD-SHELL",
+    "curl -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"getinfo\",\"params\":[],\"id\":1}' http://localhost:18232/ || exit 1"
+  ]
 }
 
 variable "enable_logging" {
   default = false
-  type = bool
+  type    = bool
 }
 
 variable "enable_domain" {
   description = "Flag to enable domain specific configurations"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "domain" {
@@ -53,19 +62,19 @@ variable "domain" {
 
 variable "zone_name" {
   default = ""
-  type = string
+  type    = string
 }
 
 variable "enable_persistent" {
   description = "A flag to enable or disable the creation of a persistent volume"
-  default = true
-  type = bool
+  default     = true
+  type        = bool
 }
 
 variable "enable_backup" {
   description = "A flag to enable or disable the creation of a backup policy"
-  default = false
-  type = bool
+  default     = false
+  type        = bool
 }
 
 variable "port_mappings" {
@@ -79,6 +88,30 @@ variable "port_mappings" {
 
 variable "persistent_volume_size" {
   description = "The size of the persistent volume"
-  default = 40
-  type = number
+  default     = 40
+  type        = number
+}
+
+variable "efs_encrypted" {
+  description = "Whether to encrypt the persistent EFS file system"
+  default     = true
+  type        = bool
+}
+
+variable "allow_all_ecs_ingress" {
+  description = "Allow all ingress to the ECS service security group"
+  default     = false
+  type        = bool
+}
+
+variable "allow_all_efs_ingress" {
+  description = "Allow all NFS ingress to the EFS security group"
+  default     = false
+  type        = bool
+}
+
+variable "create_legacy_lb_security_group" {
+  description = "Keep the legacy load balancer security group managed for existing deployments"
+  default     = false
+  type        = bool
 }

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/ecs-swaps/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/ecs-swaps/terragrunt.hcl
@@ -2,7 +2,7 @@ locals {
   # Automatically load environment-level variables
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 
-  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   # Extract out common variables for reuse
   env = local.environment_vars.locals.environment
@@ -28,28 +28,33 @@ dependency "ecr" {
 }
 
 inputs = {
-  name = "zebra-swaps"
+  name        = "zebra-swaps"
   environment = local.env
-  region = local.region_vars.locals.aws_region
-  account_id = local.account_vars.locals.aws_account_id
+  region      = local.region_vars.locals.aws_region
+  account_id  = local.account_vars.locals.aws_account_id
 
-  vpc_id = dependency.vpc.outputs.vpc_id
+  vpc_id          = dependency.vpc.outputs.vpc_id
   private_subnets = dependency.vpc.outputs.private_subnets
-  public_subnets = dependency.vpc.outputs.public_subnets
-  
-  image = "${dependency.ecr.outputs.ecr-url}:latest"
+  public_subnets  = dependency.vpc.outputs.public_subnets
 
-  task_memory=4096
-  task_cpu=1024
+  image = "${dependency.ecr.outputs.repository_url}:latest"
+
+  task_memory = 4096
+  task_cpu    = 1024
 
   enable_logging = true
-  enable_backup = false
+  enable_backup  = false
 
   enable_domain = true
-  domain = "zebra-swaps.zsa-test.net"
-  zone_name = "zsa-test.net"
+  domain        = "zebra-swaps.zsa-test.net"
+  zone_name     = "zsa-test.net"
 
   persistent_volume_size = 40
+  efs_encrypted          = false
+
+  allow_all_ecs_ingress           = true
+  allow_all_efs_ingress           = true
+  create_legacy_lb_security_group = true
 
   port_mappings = [
     // Zebra port:

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/ecs/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/ecs/terragrunt.hcl
@@ -2,7 +2,7 @@ locals {
   # Automatically load environment-level variables
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 
-  region_vars = read_terragrunt_config(find_in_parent_folders("region.hcl"))
+  region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
   # Extract out common variables for reuse
   env = local.environment_vars.locals.environment
@@ -28,30 +28,50 @@ dependency "ecr" {
 }
 
 inputs = {
-  name = "zebra"
+  name        = "zebra"
   environment = local.env
-  region = local.region_vars.locals.aws_region
-  account_id = local.account_vars.locals.aws_account_id
+  region      = local.region_vars.locals.aws_region
+  account_id  = local.account_vars.locals.aws_account_id
 
-  vpc_id = dependency.vpc.outputs.vpc_id
+  vpc_id          = dependency.vpc.outputs.vpc_id
   private_subnets = dependency.vpc.outputs.private_subnets
-  public_subnets = dependency.vpc.outputs.public_subnets
-  
-  image = "${dependency.ecr.outputs.ecr-url}:latest"
+  public_subnets  = dependency.vpc.outputs.public_subnets
 
-  task_memory=4096
-  task_cpu=1024
+  image = "${dependency.ecr.outputs.repository_url}:latest"
+
+  task_memory = 4096
+  task_cpu    = 1024
 
   enable_logging = true
-  enable_backup = false
+  enable_backup  = false
 
   enable_domain = true
-  domain = "zebra.zsa-test.net"
-  zone_name = "zsa-test.net"
+  domain        = "zebra.zsa-test.net"
+  zone_name     = "zsa-test.net"
 
   persistent_volume_size = 40
+  efs_encrypted          = false
+
+  container_health_check_command = [
+    "CMD-SHELL",
+    "true"
+  ]
+
+  allow_all_ecs_ingress           = true
+  allow_all_efs_ingress           = true
+  create_legacy_lb_security_group = true
 
   port_mappings = [
+    {
+      containerPort = 80
+      hostPort      = 80
+      protocol      = "tcp"
+    },
+    {
+      containerPort = 443
+      hostPort      = 443
+      protocol      = "tcp"
+    },
     // Zebra port:
     { // RPC PubSub
       containerPort = 18232

--- a/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda/lambda/terragrunt.hcl
+++ b/testnet-single-node-deploy/infra/terragrunt-aws-environments/dev/eu-central-1/zsa/lambda/lambda/terragrunt.hcl
@@ -4,7 +4,7 @@ locals {
 
   region_vars  = read_terragrunt_config(find_in_parent_folders("region.hcl"))
   account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
-  
+
   # Extract out common variables for reuse
   env = local.environment_vars.locals.environment
 }
@@ -27,15 +27,15 @@ dependency "lambda-role" {
 
 
 inputs = {
-  function_name = "watch-zebra-logs"
-  description   = "A simple lambda function to publicly expose logs from the Zebra ECS task"
-  memory_size   = 128
-  timeout       = 300
-  architectures = ["x86_64"]
-  package_type  = "Image"
-  image_uri     = "${dependency.ecr.outputs.ecr-url}:latest"
-  create_role   = false
-  lambda_role   = dependency.lambda-role.outputs.iam_role_arn
+  function_name          = "watch-zebra-logs"
+  description            = "A simple lambda function to publicly expose logs from the Zebra ECS task"
+  memory_size            = 128
+  timeout                = 300
+  architectures          = ["x86_64"]
+  package_type           = "Image"
+  image_uri              = "${dependency.ecr.outputs.repository_url}:latest"
+  create_role            = false
+  lambda_role            = dependency.lambda-role.outputs.iam_role_arn
   ephemeral_storage_size = 512
   tracing_config_mode    = "PassThrough"
 
@@ -50,7 +50,7 @@ inputs = {
     }
   }
 
-  create_package = false
+  create_package             = false
   create_lambda_function_url = false
 
   cloudwatch_log_group_name        = "/aws/lambda/zebra-logs"
@@ -58,6 +58,6 @@ inputs = {
 
   tags = {
     Environment = local.env
-    Terraform     = "true"
+    Terraform   = "true"
   }
 }


### PR DESCRIPTION
## Summary
- Add EFS encryption toggle, legacy LB security group, and `ignore_changes = [task_definition]` to the local ECS module.
- Fix `ecs`, `ecs-swaps`, and `lambda/lambda` to use `dependency.ecr.outputs.repository_url` (the official ECR module's output), replacing the now-nonexistent `ecr-url`.
- Fix formatting, new lines and set health check as a separate section