### PR TITLE
Add EC2 docker-conpose configuration and tunnel leader election for ZSATestnet

### DIFF
--- a/.github/workflows/ops-ec2.yaml
+++ b/.github/workflows/ops-ec2.yaml
@@ -1,0 +1,154 @@
+name: Zebra EC2 Ops
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        type: choice
+        required: true
+        options: [status, logs, genesis, restart, recreate, start, stop, deploy, apply, promote, demote]
+      image_tag:
+        description: deploy only
+        default: latest
+      instance_id:
+        description: Target a specific instance. Empty targets the leader. Required for promote.
+        default: ""
+      confirm:
+        description: Required for stop/demote — type the action name
+        default: ""
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  ops:
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_OPS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Guard destructive actions
+        if: contains(fromJSON('["stop","demote"]'), inputs.action)
+        env:
+          ACTION: ${{ inputs.action }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          [ "$CONFIRM" = "$ACTION" ] || { echo "::error::set confirm=$ACTION"; exit 1; }
+
+      # Empty instance_id resolves to the single Role=leader instance. Fails
+      # loudly on 0 or >1 rather than picking an arbitrary one. promote is the
+      # exception: its target is the *new* leader, so it must be named.
+      - id: target
+        env:
+          ACTION: ${{ inputs.action }}
+          INSTANCE_ID: ${{ inputs.instance_id }}
+        run: |
+          if [ "$ACTION" = promote ] && [ -z "$INSTANCE_ID" ]; then
+            echo "::error::promote needs an explicit instance_id — its target is the new leader"; exit 1
+          fi
+          if [ -n "$INSTANCE_ID" ]; then
+            printf '%s' "$INSTANCE_ID" | grep -Eq '^i-[0-9a-f]{8,17}$' \
+              || { echo "::error::invalid instance id: $INSTANCE_ID"; exit 1; }
+            # Confirm it is one of ours before acting on it. Without this an
+            # explicit instance_id reaches any instance in the account.
+            ID=$(aws ec2 describe-instances --instance-ids "$INSTANCE_ID" \
+              --filters "Name=tag:Name,Values=zebra-testnet" \
+                        "Name=instance-state-name,Values=running" \
+              --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
+            [ "$ID" = "$INSTANCE_ID" ] \
+              || { echo "::error::$INSTANCE_ID is not a running zebra-testnet instance"; exit 1; }
+          else
+            ID=$(aws ec2 describe-instances \
+              --filters "Name=tag:Name,Values=zebra-testnet" \
+                        "Name=tag:Role,Values=leader" \
+                        "Name=instance-state-name,Values=running" \
+              --query 'Reservations[].Instances[].InstanceId' --output text)
+            [ "$(echo $ID | wc -w)" -eq 1 ] \
+              || { echo "::error::expected 1 leader, got: '$ID'"; exit 1; }
+          fi
+          echo "id=$ID" >> $GITHUB_OUTPUT
+          echo "::notice::target $ID"
+
+      # promote/demote are tag moves, done here. The box never runs them; it
+      # only runs `apply` and matches whatever the tag now says. Both instances
+      # are applied to, so the old leader drops its connector as the new one
+      # picks it up.
+      - id: tag
+        if: contains(fromJSON('["promote","demote"]'), inputs.action)
+        env:
+          ACTION: ${{ inputs.action }}
+          TARGET_ID: ${{ steps.target.outputs.id }}
+        run: |
+          LEADER=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=zebra-testnet" \
+                      "Name=tag:Role,Values=leader" \
+                      "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+            --query 'Reservations[].Instances[].InstanceId' --output text)
+          [ "$(echo $LEADER | wc -w)" -le 1 ] \
+            || { echo "::error::more than one Role=leader: '$LEADER'"; exit 1; }
+
+          ALSO=""
+          if [ "$ACTION" = demote ]; then
+            aws ec2 delete-tags --resources "$TARGET_ID" --tags Key=Role
+          else
+            if [ -n "$LEADER" ] && [ "$LEADER" != "$TARGET_ID" ]; then
+              # A stopped incumbent cannot be stood down: SSM can't reach it, and
+              # docker's restart policy revives its connector on next start.
+              ST=$(aws ec2 describe-instances --instance-ids "$LEADER" \
+                --query 'Reservations[].Instances[].State.Name' --output text)
+              case "$ST" in
+                stopped|stopping)
+                  echo "::error::leader $LEADER is $ST — start it and demote it before promoting"; exit 1 ;;
+              esac
+              aws ec2 delete-tags --resources "$LEADER" --tags Key=Role
+              ALSO="$LEADER"
+            fi
+            aws ec2 create-tags --resources "$TARGET_ID" --tags Key=Role,Value=leader
+          fi
+          echo "also=$ALSO" >> $GITHUB_OUTPUT
+          echo "::notice::Role tag moved for $ACTION; applying to $TARGET_ID $ALSO"
+
+      - id: run
+        env:
+          ACTION: ${{ inputs.action }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          TARGET_ID: ${{ steps.target.outputs.id }}
+          ALSO_ID: ${{ steps.tag.outputs.also }}
+        run: |
+          printf '%s' "$IMAGE_TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$' \
+            || { echo "::error::invalid image tag: $IMAGE_TAG"; exit 1; }
+
+          case "$ACTION" in
+            promote|demote) OPS="apply" ;;
+            deploy)         OPS="deploy $IMAGE_TAG" ;;
+            *)              OPS="$ACTION" ;;
+          esac
+
+          send() {
+            local id=$1 cmd st inv
+            cmd=$(aws ssm send-command --instance-ids "$id" \
+              --document-name AWS-RunShellScript \
+              --parameters "$(jq -nc --arg c "bash /opt/zebra/ops.sh $OPS" '{commands:[$c]}')" \
+              --query Command.CommandId --output text)
+            for _ in $(seq 1 180); do
+              inv=$(aws ssm get-command-invocation --command-id "$cmd" \
+                --instance-id "$id" 2>/dev/null || echo '{}')
+              st=$(jq -r '.Status // "Pending"' <<<"$inv")
+              case "$st" in Success|Failed|Cancelled|TimedOut) break ;; esac
+              sleep 5
+            done
+            { echo "### $id — ops.sh $OPS"
+              jq -r '[.Status, .StandardOutputContent, .StandardErrorContent] | @tsv' <<<"$inv"
+            } | tee -a "$GITHUB_STEP_SUMMARY"
+            [ "$st" = Success ] || { echo "::error::$id: ops.sh $OPS -> $st"; return 1; }
+          }
+
+          RC=0
+          for I in $TARGET_ID $ALSO_ID; do send "$I" || RC=1; done
+          exit $RC

--- a/.github/workflows/ops-ec2.yaml
+++ b/.github/workflows/ops-ec2.yaml
@@ -47,8 +47,13 @@ jobs:
       - id: target
         env:
           ACTION: ${{ inputs.action }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
           INSTANCE_ID: ${{ inputs.instance_id }}
         run: |
+          # Validated here, before the tag step: a bad tag must not abort the
+          # run after the Role tag has already moved.
+          printf '%s' "$IMAGE_TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$' \
+            || { echo "::error::invalid image tag: $IMAGE_TAG"; exit 1; }
           if [ "$ACTION" = promote ] && [ -z "$INSTANCE_ID" ]; then
             echo "::error::promote needs an explicit instance_id — its target is the new leader"; exit 1
           fi
@@ -121,9 +126,6 @@ jobs:
           TARGET_ID: ${{ steps.target.outputs.id }}
           ALSO_ID: ${{ steps.tag.outputs.also }}
         run: |
-          printf '%s' "$IMAGE_TAG" | grep -Eq '^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$' \
-            || { echo "::error::invalid image tag: $IMAGE_TAG"; exit 1; }
-
           case "$ACTION" in
             promote|demote) OPS="apply" ;;
             deploy)         OPS="deploy $IMAGE_TAG" ;;

--- a/testnet-single-node-deploy/ec2/README.md
+++ b/testnet-single-node-deploy/ec2/README.md
@@ -23,53 +23,54 @@ All public and unauthenticated, and 18232/18233/8080 are open on the instance IP
 too. `enable_cookie_auth = false`, so anyone reaching 18232 can `stop` or
 `invalidateblock`. Disposable testnet only.
 
-## Instance tags and leader election
+## Leader election
 
 A Cloudflare Tunnel has one token, and every `cloudflared` holding it registers
 as another connector — Cloudflare then round-robins the public hostnames across
-them. So exactly one instance runs `cloudflared`: the one tagged `Role=leader`.
-**Only the leader carries that tag**; every other instance has no `Role` tag.
+them. That is meant for replicas. These nodes are not replicas: state is
+ephemeral, so each has its own chain, and two connectors means one hostname
+answering from two different chains. Hence exactly one instance may run
+`cloudflared`.
 
-`zebra-leader.service` runs `leader.sh elect` on **every** boot:
+**`Role=leader` marks that instance.** Only the leader carries the tag; every
+other instance has no `Role` tag.
+
+Nothing on the box elects, and nothing on the box writes the tag. `leader.sh
+apply` reads it and makes the box match:
 
 ```
-put-parameter /zebra/leader = <own-instance-id>   (no --overwrite)
-
-  success                            -> tag Role=leader, start cloudflared
-  ParameterAlreadyExists
-    holder gone/terminated/stopped   -> overwrite, tag, start cloudflared
-    holder running                   -> untag, stop own cloudflared
+Role=leader present -> ensure cloudflared up
+absent              -> ensure cloudflared down
 ```
 
-Without `--overwrite` the write fails if the key exists. That single atomic write
-is the whole election — two instances booting at once cannot both win.
+That runs at boot (`zebra-leader.service`) and on demand (`ops.sh apply`). There
+is no shared lock, no claim, and no state two boxes can disagree about — the tag
+is written in one place and every box is a follower of it.
 
-Nothing releases the parameter when a leader dies; termination runs no hook.
-Cleanup is lazy: the next instance to boot fails its claim, sees the holder is
-gone, and overwrites. Terminate everything, launch one, and the hostnames come
-back with no manual step.
+The ops workflow owns the verbs:
 
-Electing on every boot (not just first boot) is what makes taking over from a
-*stopped* holder safe. Compose uses `restart: unless-stopped`, so a box that lost
-the claim while stopped would otherwise have docker resurrect its connector,
-putting two on one tunnel — hence the losing branch stops cloudflared rather than
-just skipping it.
+| | |
+| --- | --- |
+| `promote B` | untag the current leader, tag B, `apply` to both |
+| `demote` | untag, `apply` |
+| leader terminated | nothing reclaims automatically — `promote` the replacement |
+| `up` fails | `apply` exits non-zero; run it again |
 
-`ops.sh promote` / `demote` move the tunnel without relaunching; `demote` also
-deletes the parameter so another node can claim it. `ops.sh status` prints
-`self=` and `leader=`.
+Two things keep a stale connector from coming back. `cloudflared` sits in the
+`tunnel` compose profile, so a bare `docker compose up -d` never starts one —
+only `leader.sh` does. And `restart: unless-stopped` revives the leader's
+connector after a reboot, which `apply` at boot undoes on a box that lost the tag
+while it was stopped.
 
-**`Name=zebra-testnet`** is how ops finds the box. The ops workflow with
-`instance_id` empty resolves `Name` + `Role=leader` + running and fails unless
-that is exactly one instance; set `instance_id` to target any other. Note the IAM
-role scopes `ssm:SendCommand` by `ssm:resourceTag/Name` against `instance/*`, so
-the `Name` tag is effectively a capability — tagging any instance in the account
-`zebra-testnet` grants the ops role shell on it.
+Instance profile needs only `ec2:DescribeTags` and `ssm:GetParameter`+
+`kms:Decrypt` on the tunnel token — no write permissions at all. Enabling
+instance metadata tags on the launch template would drop `ec2:DescribeTags` too,
+making `is_leader` a plain IMDS read.
 
-Election needs, on the instance profile: `ssm:PutParameter`/`GetParameter`/
-`DeleteParameter` on `/zebra/leader`, `ssm:GetParameter`+`kms:Decrypt` on the
-tunnel token, `ec2:CreateTags`+`ec2:DeleteTags` on itself scoped to the `Role`
-key, and `ec2:DescribeInstances`.
+**`Name=zebra-testnet`** is how ops finds the box. The IAM role scopes
+`ssm:SendCommand` by `ssm:resourceTag/Name` against `instance/*`, so that tag is
+effectively a capability — tagging any instance in the account `zebra-testnet`
+grants the ops role shell on it.
 
 ## Genesis
 
@@ -103,7 +104,8 @@ Must be built from this branch — its `zebra-network/src/config.rs` makes
 every block is rejected with `Deferred(-7875000000000)`. 20-40 min cold.
 
 **2. Launch** — Console → Launch Templates → `zebra-testnet` → *Launch instance
-from template*. First boot takes 2-3 min and elects.
+from template*. First boot takes 2-3 min. It comes up without a connector until
+the workflow tags it `Role=leader`.
 
 **3. Genesis + verify**
 
@@ -126,8 +128,8 @@ ZCASH_NODE_ADDRESS=rpc.test-zsa.org ZCASH_NODE_PORT=443 ZCASH_NODE_PROTOCOL=http
 ## ops.sh
 
 `deploy <tag>` · `restart` · `start` · `stop` · `recreate` · `genesis` · `logs` ·
-`status` · `promote` · `demote`. Everything that starts the node re-serves
-genesis.
+`status` · `apply`. Everything that starts the node re-serves genesis.
+`promote`/`demote` are workflow actions, not box actions — see above.
 
 Normally driven by the ops workflow. To run an action by hand — the box has no
 inbound ports and no SSH key, so it goes over SSM:

--- a/testnet-single-node-deploy/ec2/README.md
+++ b/testnet-single-node-deploy/ec2/README.md
@@ -149,8 +149,8 @@ aws ssm get-command-invocation --region "$REGION" \
   --query '[Status,StandardOutputContent,StandardErrorContent]' --output text
 ```
 
-ECR login expires after 12h and the box only logs in at first boot, so a manual
-`deploy` on an older box 401s — `docker login` first.
+`deploy` refreshes the ECR login itself before pulling, since the box's
+boot-time token expires after 12h.
 
 ## Changing a running box
 

--- a/testnet-single-node-deploy/ec2/README.md
+++ b/testnet-single-node-deploy/ec2/README.md
@@ -1,0 +1,146 @@
+# ZSATestnet on EC2
+
+Four containers on one box running `../testnet-config.toml` (ZSATestnet, magic
+`5a534131`, NU5/6/7 at height 1, no PoW, no peers). The launch template was
+created manually in the console; the box is driven by GitHub Actions over SSM.
+
+| File | On the box |
+| --- | --- |
+| `docker-compose.yml` | `/opt/zebra/` |
+| `ops.sh`, `leader.sh`, `logs-api.py` | `/opt/zebra/` |
+| `zebra-leader.service` | `/etc/systemd/system/` |
+
+zebrad reads the config baked into the image; override single keys with
+`ZEBRA_SECTION__KEY` env vars in compose.
+
+| URL | |
+| --- | --- |
+| `rpc.test-zsa.org` | JSON-RPC, POST only |
+| `logs.test-zsa.org` | JSON logs, `?limit=N` (max 500) |
+| `dozzle.test-zsa.org` | log UI |
+
+All public and unauthenticated, and 18232/18233/8080 are open on the instance IP
+too. `enable_cookie_auth = false`, so anyone reaching 18232 can `stop` or
+`invalidateblock`. Disposable testnet only.
+
+## Instance tags and leader election
+
+A Cloudflare Tunnel has one token, and every `cloudflared` holding it registers
+as another connector — Cloudflare then round-robins the public hostnames across
+them. So exactly one instance runs `cloudflared`: the one tagged `Role=leader`.
+**Only the leader carries that tag**; every other instance has no `Role` tag.
+
+`zebra-leader.service` runs `leader.sh elect` on **every** boot:
+
+```
+put-parameter /zebra/leader = <own-instance-id>   (no --overwrite)
+
+  success                            -> tag Role=leader, start cloudflared
+  ParameterAlreadyExists
+    holder gone/terminated/stopped   -> overwrite, tag, start cloudflared
+    holder running                   -> untag, stop own cloudflared
+```
+
+Without `--overwrite` the write fails if the key exists. That single atomic write
+is the whole election — two instances booting at once cannot both win.
+
+Nothing releases the parameter when a leader dies; termination runs no hook.
+Cleanup is lazy: the next instance to boot fails its claim, sees the holder is
+gone, and overwrites. Terminate everything, launch one, and the hostnames come
+back with no manual step.
+
+Electing on every boot (not just first boot) is what makes taking over from a
+*stopped* holder safe. Compose uses `restart: unless-stopped`, so a box that lost
+the claim while stopped would otherwise have docker resurrect its connector,
+putting two on one tunnel — hence the losing branch stops cloudflared rather than
+just skipping it.
+
+`ops.sh promote` / `demote` move the tunnel without relaunching; `demote` also
+deletes the parameter so another node can claim it. `ops.sh status` prints
+`self=` and `leader=`.
+
+**`Name=zebra-testnet`** is how ops finds the box. The ops workflow with
+`instance_id` empty resolves `Name` + `Role=leader` + running and fails unless
+that is exactly one instance; set `instance_id` to target any other. Note the IAM
+role scopes `ssm:SendCommand` by `ssm:resourceTag/Name` against `instance/*`, so
+the `Name` tag is effectively a capability — tagging any instance in the account
+`zebra-testnet` grants the ops role shell on it.
+
+Election needs, on the instance profile: `ssm:PutParameter`/`GetParameter`/
+`DeleteParameter` on `/zebra/leader`, `ssm:GetParameter`+`kms:Decrypt` on the
+tunnel token, `ec2:CreateTags`+`ec2:DeleteTags` on itself scoped to the `Role`
+key, and `ec2:DescribeInstances`.
+
+## Genesis
+
+Zebra hard-codes genesis for Regtest only. This network has none and no peers, so
+the node parks at `current_height=None` until it is POSTed to `submitblock`.
+`ops.sh` does it from the vector in the image:
+
+```sh
+hex=$(docker exec zebra-testnet cat /app/zebra-test/src/vectors/block-test-0-000-000.txt | tr -d '[:space:]')
+curl -s http://127.0.0.1:18232 -X POST -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"1.0\",\"id\":\"ops\",\"method\":\"submitblock\",\"params\":[\"$hex\"]}"
+```
+
+State is ephemeral, so this repeats after every start — `ops.sh` calls it on
+`deploy`/`restart`/`start`/`recreate`. Idempotent (already-committed → HTTP 200
+`"rejected"`). **Docker restarts do not trigger it**: after a crash the node comes
+back empty and stays at height 0 until someone runs `ops.sh genesis`.
+
+## End to end
+
+**1. Build and push** — CI `push-ecr.yaml` on merge, or:
+
+```sh
+REPO=496038263219.dkr.ecr.eu-central-1.amazonaws.com/dev-zebra-server
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin ${REPO%%/*}
+docker build -f testnet-single-node-deploy/dockerfile -t $REPO:latest . && docker push $REPO:latest
+```
+
+Must be built from this branch — its `zebra-network/src/config.rs` makes
+`funding_streams = []` actually clear the default testnet streams; without it
+every block is rejected with `Deferred(-7875000000000)`. 20-40 min cold.
+
+**2. Launch** — Console → Launch Templates → `zebra-testnet` → *Launch instance
+from template*. First boot takes 2-3 min and elects.
+
+**3. Genesis + verify**
+
+```sh
+aws ssm send-command --region eu-central-1 --instance-ids <id> \
+  --document-name AWS-RunShellScript --parameters 'commands=["bash /opt/zebra/ops.sh genesis"]'
+curl -s https://rpc.test-zsa.org -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"1.0","id":"1","method":"getblockchaininfo","params":[]}'
+```
+
+**4. Drive it** — nothing mines on its own; `zcash_tx_tool` mines via
+`getblocktemplate`/`submitblock`. Keep `REGTEST_NETWORK` (`TEST_NETWORK` has no
+NU7):
+
+```sh
+ZCASH_NODE_ADDRESS=rpc.test-zsa.org ZCASH_NODE_PORT=443 ZCASH_NODE_PROTOCOL=https \
+  ./target/release/zcash_tx_tool test-orchard-zsa
+```
+
+## ops.sh
+
+`deploy <tag>` · `restart` · `start` · `stop` · `recreate` · `genesis` · `logs` ·
+`status` · `promote` · `demote`. Everything that starts the node re-serves
+genesis.
+
+ECR login expires after 12h and the box only logs in at first boot, so a manual
+`deploy` on an older box 401s — `docker login` first.
+
+## Changing a running box
+
+`user_data` runs at first boot only:
+
+```sh
+aws ssm start-session --target <id>
+sudo vi /opt/zebra/docker-compose.yml
+sudo bash /opt/zebra/ops.sh recreate
+```
+
+Relaunching from the template is the only way the box provably matches this
+directory.

--- a/testnet-single-node-deploy/ec2/README.md
+++ b/testnet-single-node-deploy/ec2/README.md
@@ -94,7 +94,7 @@ back empty and stays at height 0 until someone runs `ops.sh genesis`.
 
 ```sh
 REPO=496038263219.dkr.ecr.eu-central-1.amazonaws.com/dev-zebra-server
-aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin ${REPO%%/*}
+aws ecr get-login-password --region "${AWS_REGION:-eu-central-1}" | docker login --username AWS --password-stdin ${REPO%%/*}
 docker build -f testnet-single-node-deploy/dockerfile -t $REPO:latest . && docker push $REPO:latest
 ```
 
@@ -108,7 +108,7 @@ from template*. First boot takes 2-3 min and elects.
 **3. Genesis + verify**
 
 ```sh
-aws ssm send-command --region eu-central-1 --instance-ids <id> \
+aws ssm send-command --region "${AWS_REGION:-eu-central-1}" --instance-ids <id> \
   --document-name AWS-RunShellScript --parameters 'commands=["bash /opt/zebra/ops.sh genesis"]'
 curl -s https://rpc.test-zsa.org -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"1.0","id":"1","method":"getblockchaininfo","params":[]}'
@@ -128,6 +128,24 @@ ZCASH_NODE_ADDRESS=rpc.test-zsa.org ZCASH_NODE_PORT=443 ZCASH_NODE_PROTOCOL=http
 `deploy <tag>` · `restart` · `start` · `stop` · `recreate` · `genesis` · `logs` ·
 `status` · `promote` · `demote`. Everything that starts the node re-serves
 genesis.
+
+Normally driven by the ops workflow. To run an action by hand — the box has no
+inbound ports and no SSH key, so it goes over SSM:
+
+```sh
+REGION=${AWS_REGION:-eu-central-1}
+aws ssm send-command --region "$REGION" --instance-ids <id> \
+  --document-name AWS-RunShellScript \
+  --parameters 'commands=["bash /opt/zebra/ops.sh <action> [tag]"]'
+```
+
+Output comes back separately:
+
+```sh
+aws ssm get-command-invocation --region "$REGION" \
+  --command-id <command-id> --instance-id <id> \
+  --query '[Status,StandardOutputContent,StandardErrorContent]' --output text
+```
 
 ECR login expires after 12h and the box only logs in at first boot, so a manual
 `deploy` on an older box 401s — `docker login` first.

--- a/testnet-single-node-deploy/ec2/docker-compose.yml
+++ b/testnet-single-node-deploy/ec2/docker-compose.yml
@@ -19,10 +19,19 @@ services:
         max-size: "50m"
         max-file: "5"
 
+  # Started and stopped only by leader.sh. The profile keeps a bare
+  # `docker compose up -d` from starting a second connector by accident;
+  # `unless-stopped` brings the leader's back after a reboot, and leader.sh
+  # stops it at boot on a box that is no longer the leader.
   cloudflared:
+    profiles: [tunnel]
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel run --token ${CF_TUNNEL_TOKEN}
+    # Token via env, not argv: on the command line it shows up in `docker
+    # inspect` and the host process list.
+    environment:
+      - TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
+    command: tunnel run
 
   dozzle:
     image: amir20/dozzle:latest

--- a/testnet-single-node-deploy/ec2/docker-compose.yml
+++ b/testnet-single-node-deploy/ec2/docker-compose.yml
@@ -1,0 +1,44 @@
+# IMAGE and CF_TUNNEL_TOKEN come from /opt/zebra/.env
+services:
+  zebra-testnet:
+    image: ${IMAGE}
+    container_name: zebra-testnet
+    restart: unless-stopped
+    # The image ENTRYPOINT hardcodes regtest-config.toml
+    entrypoint: ["target/release/zebrad", "-c", "/app/testnet-single-node-deploy/testnet-config.toml"]
+    environment:
+      # Only delta from the in-image config: the node is driven remotely, and
+      # without this zebrad reports itself ~4.1M blocks behind real Testnet and
+      # getblocktemplate refuses.
+      - ZEBRA_RPC__DEBUG_FORCE_FINISHED_SYNC=true
+    ports:
+      - "18232:18232" # RPC, unauthenticated
+      - "18233:18233" # P2P
+    logging:
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel run --token ${CF_TUNNEL_TOKEN}
+
+  dozzle:
+    image: amir20/dozzle:latest
+    restart: unless-stopped
+    environment:
+      - DOZZLE_FILTER=name=zebra-testnet
+      - DOZZLE_NO_ANALYTICS=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  logs-api:
+    image: python:3.12-slim
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /opt/zebra/logs-api.py:/app/logs-api.py:ro
+    command: ["python", "-u", "/app/logs-api.py"]

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 # /opt/zebra/leader.sh <elect|promote|demote|status>
 #
-# The leader is the one instance tagged Role=leader, and the only one running
-# cloudflared — two connectors on one tunnel makes Cloudflare round-robin the
-# public hostnames between nodes on divergent chains.
+# The leader is the one instance tagged Role=leader, and the only one running cloudflared.
 #
 # Claim is an SSM put-parameter WITHOUT --overwrite, which fails if the key
 # exists. That is the atomic bit: simultaneous boots cannot both win.

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 PARAM=/zebra/leader
 REGION="${AWS_REGION:-eu-central-1}"
 
-TOKEN=$(curl -sX PUT http://169.254.169.254/latest/api/token \
+IMDS=http://169.254.169.254/latest
+
+TOKEN=$(curl -sX PUT "$IMDS/api/token" \
   -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
 ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
-  http://169.254.169.254/latest/meta-data/instance-id)
+  "$IMDS/meta-data/instance-id")
 
 put() { aws ssm put-parameter --region "$REGION" --name "$PARAM" \
   --type String --value "$ID" "$@" >/dev/null; }

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -38,13 +38,16 @@ untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Ro
 # it has lost and shuts its own cloudflared down.
 claim() {
   put 2>/dev/null && return 0
-  local cur state rc
+  local cur state rc errf
   cur=$(get); rc=$?
   [ $rc -eq 2 ] && return 1
   [ $rc -eq 1 ] && { put --overwrite; return 0; }
   [ "$cur" = "$ID" ] && return 0
+  errf=$(mktemp)
   state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
-    --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo gone)
+    --query 'Reservations[].Instances[].State.Name' --output text 2>"$errf") ||
+    { grep -q InvalidInstanceID "$errf" || { rm -f "$errf"; return 1; }; state=gone; }
+  rm -f "$errf"
   case "$state" in
     ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite; return 0 ;;
     *) return 1 ;;

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -1,81 +1,60 @@
 #!/usr/bin/env bash
-# /opt/zebra/leader.sh <elect|promote|demote|status>
+# /opt/zebra/leader.sh [apply|status]
 #
-# The leader is the one instance tagged Role=leader, and the only one running cloudflared.
+# Only one instance may run cloudflared. Every process holding the tunnel token
+# registers as another connector and Cloudflare load-balances across them, but
+# these nodes are not replicas — each has its own ephemeral chain, so two
+# connectors means one hostname answering from two different chains.
 #
-# Claim is an SSM put-parameter WITHOUT --overwrite, which fails if the key
-# exists. That is the atomic bit: simultaneous boots cannot both win.
+# Role=leader marks the instance allowed to run it. The ops workflow writes that
+# tag; this script only makes the box match it. Nothing here elects and nothing
+# here writes the tag, so there is no shared state to race over.
 set -euo pipefail
-PARAM=/zebra/leader
+cd /opt/zebra
 REGION="${AWS_REGION:-eu-central-1}"
-
+TOKEN_PARAM=/zebra/zebra-testnet/cf-tunnel-token
 IMDS=http://169.254.169.254/latest
 
-TOKEN=$(curl -sX PUT "$IMDS/api/token" \
+T=$(curl -sf --retry 5 --retry-delay 1 -X PUT "$IMDS/api/token" \
   -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
-ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+ID=$(curl -sf --retry 5 --retry-delay 1 -H "X-aws-ec2-metadata-token: $T" \
   "$IMDS/meta-data/instance-id")
+[[ $ID == i-* ]] || { echo "bad instance id: '$ID'" >&2; exit 1; }
 
-put() { aws ssm put-parameter --region "$REGION" --name "$PARAM" \
-  --type String --value "$ID" "$@" >/dev/null; }
-# 0 = value on stdout, 1 = unclaimed, 2 = could not tell
-get() {
-  local out errf rc
-  errf=$(mktemp)
-  out=$(aws ssm get-parameter --region "$REGION" --name "$PARAM" \
-        --query Parameter.Value --output text 2>"$errf"); rc=$?
-  if [ $rc -eq 0 ]; then rm -f "$errf"; printf '%s' "$out"; return 0; fi
-  if grep -q ParameterNotFound "$errf"; then rm -f "$errf"; return 1; fi
-  echo "leader: cannot read $PARAM: $(cat "$errf")" >&2
-  rm -f "$errf"
-  return 2
-}
-# Role=leader exists only on the leader. Followers carry no Role tag at all.
-tag()   { aws ec2 create-tags --region "$REGION" --resources "$ID" --tags Key=Role,Value=leader; }
-untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Role; }
+# cloudflared sits in a compose profile, so a bare `docker compose up -d` cannot
+# start a connector by accident. Always address it through the profile.
+dc() { docker compose --profile tunnel "$@"; }
+running() { [ -n "$(dc ps -q cloudflared)" ]; }
+# Prints the Role tag, or "None". Non-zero means we could not find out, which is
+# not the same as "not the leader" — see the hard exit below.
+role() { aws ec2 describe-tags --region "$REGION" \
+  --filters "Name=resource-id,Values=$ID" "Name=key,Values=Role" \
+  --query 'Tags[0].Value' --output text; }
 
-# 0 if we hold the claim afterwards. Takes over from any holder that is not
-# actually serving: gone, terminated, or stopped. Safe because elect runs on
-# every boot (zebra-leader.service), so a stopped holder that comes back finds
-# it has lost and shuts its own cloudflared down.
-claim() {
-  put 2>/dev/null && return 0
-  local cur state rc errf
-  cur=$(get); rc=$?
-  [ $rc -eq 2 ] && return 1
-  [ $rc -eq 1 ] && { put --overwrite; return; }
-  [ "$cur" = "$ID" ] && return 0
-  errf=$(mktemp)
-  state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
-    --query 'Reservations[].Instances[].State.Name' --output text 2>"$errf") ||
-    { grep -q InvalidInstanceID "$errf" || { rm -f "$errf"; return 1; }; state=gone; }
-  rm -f "$errf"
-  case "$state" in
-    ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite ;;
-    *) return 1 ;;
-  esac
-}
-
-start_tunnel() {
+up() {
+  if running; then return 0; fi
   local t
-  t=$(aws ssm get-parameter --region "$REGION" --name /zebra/zebra-testnet/cf-tunnel-token \
+  t=$(aws ssm get-parameter --region "$REGION" --name "$TOKEN_PARAM" \
     --with-decryption --query Parameter.Value --output text)
-  sed -i "s|^CF_TUNNEL_TOKEN=.*|CF_TUNNEL_TOKEN=$t|" /opt/zebra/.env
-  cd /opt/zebra && docker compose up -d cloudflared
+  grep -q '^CF_TUNNEL_TOKEN=' .env || { echo "no CF_TUNNEL_TOKEN= line in .env" >&2; return 1; }
+  sed -i "s|^CF_TUNNEL_TOKEN=.*|CF_TUNNEL_TOKEN=$t|" .env
+  dc up -d cloudflared
 }
 
-case "${1:-elect}" in
-  # Runs at every boot. Losing means stopping our own cloudflared: docker's
-  # restart policy would otherwise resurrect it on a box that lost the claim
-  # while it was stopped, putting two connectors on the tunnel.
-  elect)   if claim; then tag; start_tunnel; echo leader
-           else untag 2>/dev/null || true
-                cd /opt/zebra && docker compose stop cloudflared >/dev/null 2>&1 || true
-                echo follower; fi ;;
-  promote) put --overwrite; tag; start_tunnel; echo "leader: $ID" ;;
-  # Releases the claim too, so the next elect can take over while this box lives.
-  demote)  untag; aws ssm delete-parameter --region "$REGION" --name "$PARAM" 2>/dev/null || true
-           cd /opt/zebra && docker compose stop cloudflared; echo "released: $ID" ;;
-  status)  cur=$(get) || cur="<unset>"; echo "self=$ID leader=$cur" ;;
-  *) echo "usage: leader.sh <elect|promote|demote|status>"; exit 2 ;;
-esac
+ACTION="${1:-apply}"
+case $ACTION in apply|status) ;; *) echo "usage: leader.sh [apply|status]" >&2; exit 2 ;; esac
+
+# Fail closed. A throttled or denied lookup must not read as "not the leader",
+# which would take the tunnel down over a transient API error.
+R=$(role) || { echo "Role tag lookup failed; leaving cloudflared as-is" >&2; exit 1; }
+
+# apply runs at boot and on demand. At boot it also undoes docker's restart
+# policy reviving a connector on a box that lost the tag while it was stopped.
+if [ "$ACTION" = status ]; then
+  echo "self=$ID leader=$([ "$R" = leader ] && echo yes || echo no)" \
+       "cloudflared=$(running && echo up || echo down)"
+elif [ "$R" = leader ]; then
+  up
+else
+  dc stop cloudflared >/dev/null
+fi

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -41,7 +41,7 @@ claim() {
   local cur state rc errf
   cur=$(get); rc=$?
   [ $rc -eq 2 ] && return 1
-  [ $rc -eq 1 ] && { put --overwrite; return 0; }
+  [ $rc -eq 1 ] && { put --overwrite; return; }
   [ "$cur" = "$ID" ] && return 0
   errf=$(mktemp)
   state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
@@ -49,7 +49,7 @@ claim() {
     { grep -q InvalidInstanceID "$errf" || { rm -f "$errf"; return 1; }; state=gone; }
   rm -f "$errf"
   case "$state" in
-    ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite; return 0 ;;
+    ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite ;;
     *) return 1 ;;
   esac
 }

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# /opt/zebra/leader.sh <elect|promote|demote|status>
+#
+# The leader is the one instance tagged Role=leader, and the only one running
+# cloudflared — two connectors on one tunnel makes Cloudflare round-robin the
+# public hostnames between nodes on divergent chains.
+#
+# Claim is an SSM put-parameter WITHOUT --overwrite, which fails if the key
+# exists. That is the atomic bit: simultaneous boots cannot both win.
+set -euo pipefail
+PARAM=/zebra/leader
+REGION="${AWS_REGION:-eu-central-1}"
+
+TOKEN=$(curl -sX PUT http://169.254.169.254/latest/api/token \
+  -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
+ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id)
+
+put() { aws ssm put-parameter --region "$REGION" --name "$PARAM" \
+  --type String --value "$ID" "$@" >/dev/null; }
+get() { aws ssm get-parameter --region "$REGION" --name "$PARAM" \
+  --query Parameter.Value --output text 2>/dev/null || true; }
+# Role=leader exists only on the leader. Followers carry no Role tag at all.
+tag()   { aws ec2 create-tags --region "$REGION" --resources "$ID" --tags Key=Role,Value=leader; }
+untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Role; }
+
+# 0 if we hold the claim afterwards. Takes over from any holder that is not
+# actually serving: gone, terminated, or stopped. Safe because elect runs on
+# every boot (zebra-leader.service), so a stopped holder that comes back finds
+# it has lost and shuts its own cloudflared down.
+claim() {
+  put 2>/dev/null && return 0
+  local cur state
+  cur=$(get)
+  [ "$cur" = "$ID" ] && return 0
+  state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
+    --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo gone)
+  case "$state" in
+    ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite; return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+start_tunnel() {
+  local t
+  t=$(aws ssm get-parameter --region "$REGION" --name /zebra/zebra-testnet/cf-tunnel-token \
+    --with-decryption --query Parameter.Value --output text)
+  sed -i "s|^CF_TUNNEL_TOKEN=.*|CF_TUNNEL_TOKEN=$t|" /opt/zebra/.env
+  cd /opt/zebra && docker compose up -d cloudflared
+}
+
+case "${1:-elect}" in
+  # Runs at every boot. Losing means stopping our own cloudflared: docker's
+  # restart policy would otherwise resurrect it on a box that lost the claim
+  # while it was stopped, putting two connectors on the tunnel.
+  elect)   if claim; then tag; start_tunnel; echo leader
+           else untag 2>/dev/null || true
+                cd /opt/zebra && docker compose stop cloudflared >/dev/null 2>&1 || true
+                echo follower; fi ;;
+  promote) put --overwrite; tag; start_tunnel; echo "leader: $ID" ;;
+  # Releases the claim too, so the next elect can take over while this box lives.
+  demote)  untag; aws ssm delete-parameter --region "$REGION" --name "$PARAM" 2>/dev/null || true
+           cd /opt/zebra && docker compose stop cloudflared; echo "released: $ID" ;;
+  status)  echo "self=$ID leader=$(get)" ;;
+  *) echo "usage: leader.sh <elect|promote|demote|status>"; exit 2 ;;
+esac

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -16,8 +16,18 @@ ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
 
 put() { aws ssm put-parameter --region "$REGION" --name "$PARAM" \
   --type String --value "$ID" "$@" >/dev/null; }
-get() { aws ssm get-parameter --region "$REGION" --name "$PARAM" \
-  --query Parameter.Value --output text 2>/dev/null || true; }
+# 0 = value on stdout, 1 = unclaimed, 2 = could not tell
+get() {
+  local out errf rc
+  errf=$(mktemp)
+  out=$(aws ssm get-parameter --region "$REGION" --name "$PARAM" \
+        --query Parameter.Value --output text 2>"$errf"); rc=$?
+  if [ $rc -eq 0 ]; then rm -f "$errf"; printf '%s' "$out"; return 0; fi
+  if grep -q ParameterNotFound "$errf"; then rm -f "$errf"; return 1; fi
+  echo "leader: cannot read $PARAM: $(cat "$errf")" >&2
+  rm -f "$errf"
+  return 2
+}
 # Role=leader exists only on the leader. Followers carry no Role tag at all.
 tag()   { aws ec2 create-tags --region "$REGION" --resources "$ID" --tags Key=Role,Value=leader; }
 untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Role; }
@@ -28,8 +38,10 @@ untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Ro
 # it has lost and shuts its own cloudflared down.
 claim() {
   put 2>/dev/null && return 0
-  local cur state
-  cur=$(get)
+  local cur state rc
+  cur=$(get); rc=$?
+  [ $rc -eq 2 ] && return 1
+  [ $rc -eq 1 ] && { put --overwrite; return 0; }
   [ "$cur" = "$ID" ] && return 0
   state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
     --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo gone)
@@ -59,6 +71,6 @@ case "${1:-elect}" in
   # Releases the claim too, so the next elect can take over while this box lives.
   demote)  untag; aws ssm delete-parameter --region "$REGION" --name "$PARAM" 2>/dev/null || true
            cd /opt/zebra && docker compose stop cloudflared; echo "released: $ID" ;;
-  status)  echo "self=$ID leader=$(get)" ;;
+  status)  cur=$(get) || cur="<unset>"; echo "self=$ID leader=$cur" ;;
   *) echo "usage: leader.sh <elect|promote|demote|status>"; exit 2 ;;
 esac

--- a/testnet-single-node-deploy/ec2/logs-api.py
+++ b/testnet-single-node-deploy/ec2/logs-api.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Read-only zebrad log endpoint. One container, JSON, no actions.
+
+Stdlib only, so a stock python:*-slim image needs no pip install.
+"""
+
+import functools
+import json
+import re
+import socket
+import http.client
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+SERVICE_VERSION = "1.0.0"
+CONTAINER = "zebra-testnet"
+DOCKER_SOCK = "/var/run/docker.sock"
+LISTEN_PORT = 8080
+DEFAULT_LIMIT = 200
+MAX_LIMIT = 500
+# How far past container start to look for the startup banner.
+STARTUP_WINDOW_SECS = 120
+
+VERSION_PATTERNS = {
+    "version": r"version:\s*([^\n]+)",
+    "zcash_network": r"Zcash network:\s*([^\n]+)",
+    "running_state_version": r"running state version:\s*([^\n]+)",
+    "initial_disk_state_version": r"initial disk state version:\s*([^\n]+)",
+    "features": r"features:\s*([^\n]+)",
+    "target_triple": r"target triple:\s*([^\n]+)",
+    "rust_compiler": r"rust compiler:\s*([^\n]+)",
+    "rust_release_date": r"rust release date:\s*([^\n]+)",
+    "optimization_level": r"optimization level:\s*([^\n]+)",
+    "debug_checks": r"debug checks:\s*([^\n]+)",
+    "git_tag": r"git tag:\s*([^\n]+)",
+    "git_commit_full": r"git commit full:\s*([^\n]+)",
+}
+
+
+class _UnixHTTPConnection(http.client.HTTPConnection):
+    """HTTPConnection over a unix socket (the Docker Engine API)."""
+
+    def __init__(self, sock_path, timeout=15):
+        super().__init__("localhost", timeout=timeout)
+        self._sock_path = sock_path
+
+    def connect(self):
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(self.timeout)
+        s.connect(self._sock_path)
+        self.sock = s
+
+
+def _docker_get(path):
+    conn = _UnixHTTPConnection(DOCKER_SOCK)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def _demux(raw, tty):
+    """Docker 8-byte-frames stdout/stderr unless the container has a TTY."""
+    if tty:
+        return raw.decode("utf-8", "replace")
+    out = []
+    i = 0
+    while i + 8 <= len(raw):
+        size = int.from_bytes(raw[i + 4 : i + 8], "big")
+        i += 8
+        out.append(raw[i : i + size].decode("utf-8", "replace"))
+        i += size
+    return "".join(out)
+
+
+def _inspect():
+    status, body = _docker_get(f"/containers/{CONTAINER}/json")
+    if status != 200:
+        raise RuntimeError(f"docker inspect {CONTAINER} returned HTTP {status}")
+    return json.loads(body)
+
+
+def _log_lines(query, tty):
+    status, body = _docker_get(f"/containers/{CONTAINER}/logs?{query}")
+    if status != 200:
+        raise RuntimeError(f"docker logs {CONTAINER} returned HTTP {status}")
+    text = _demux(body, tty)
+    return [ln for ln in text.splitlines() if ln.strip()]
+
+
+def _extract_version_info(lines):
+    return {
+        key: next((m.group(1).strip() for ln in lines if (m := re.search(pat, ln))), "Not found")
+        for key, pat in VERSION_PATTERNS.items()
+    }
+
+
+@functools.lru_cache(maxsize=1)
+def _version_info(started_at, tty):
+    try:
+        start = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        since = int(start.timestamp())
+    except Exception:
+        since = 0
+    # Bounded: avoids pulling the whole log history.
+    q = f"stdout=1&stderr=1&since={since}&until={since + STARTUP_WINDOW_SECS}"
+    return _extract_version_info(_log_lines(q, tty))
+
+
+def build_payload(limit):
+    meta = _inspect()
+    tty = bool(meta.get("Config", {}).get("Tty"))
+    started_at = meta.get("State", {}).get("StartedAt", "")
+
+    version_info = _version_info(started_at, tty)
+    logs = _log_lines(f"stdout=1&stderr=1&tail={limit}", tty)
+
+    return {
+        "logStreamName": f"docker/{CONTAINER}",
+        "versionInfo": version_info,
+        "containerState": meta.get("State", {}).get("Status", "unknown"),
+        "containerStartedAt": started_at,
+        "logCount": len(logs),
+        "logs": logs,
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "zebra-logs-api/" + SERVICE_VERSION
+
+    def _send(self, code, obj):
+        body = json.dumps(obj, indent=4).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/healthz"):
+            self._send(200, {"ok": True})
+            return
+
+        q = parse_qs(urlparse(self.path).query)
+        try:
+            limit = int(q.get("limit", [DEFAULT_LIMIT])[0])
+        except ValueError:
+            limit = DEFAULT_LIMIT
+        limit = max(1, min(limit, MAX_LIMIT))
+
+        try:
+            self._send(200, build_payload(limit))
+        except Exception as exc:
+            self._send(500, {"error": str(exc)})
+
+    def do_POST(self):
+        self._send(405, {"error": "method not allowed"})
+
+    do_PUT = do_DELETE = do_PATCH = do_POST
+
+    def log_message(self, fmt, *args):
+        print(f"{datetime.now(timezone.utc).isoformat()} {fmt % args}", flush=True)
+
+
+if __name__ == "__main__":
+    print(
+        f"zebra-logs-api {SERVICE_VERSION} container={CONTAINER} port={LISTEN_PORT}",
+        flush=True,
+    )
+    ThreadingHTTPServer(("0.0.0.0", LISTEN_PORT), Handler).serve_forever()

--- a/testnet-single-node-deploy/ec2/logs-api.py
+++ b/testnet-single-node-deploy/ec2/logs-api.py
@@ -20,7 +20,7 @@ LISTEN_PORT = 8080
 DEFAULT_LIMIT = 200
 MAX_LIMIT = 500
 # How far past container start to look for the startup banner.
-STARTUP_WINDOW_SECS = 120
+STARTUP_WINDOW_SECS = 240
 
 VERSION_PATTERNS = {
     "version": r"version:\s*([^\n]+)",
@@ -155,7 +155,10 @@ class Handler(BaseHTTPRequestHandler):
         try:
             self._send(200, build_payload(limit))
         except Exception as exc:
-            self._send(500, {"error": str(exc)})
+            # Detail goes to the container log; the endpoint is public, so the
+            # response says nothing about internals.
+            self.log_message("error building payload: %s", exc)
+            self._send(500, {"error": "internal error"})
 
     def do_POST(self):
         self._send(405, {"error": "method not allowed"})

--- a/testnet-single-node-deploy/ec2/ops.sh
+++ b/testnet-single-node-deploy/ec2/ops.sh
@@ -17,6 +17,11 @@ serve_genesis() {
 
 case "$ACTION" in
   deploy)     sed -i "s|^IMAGE=.*|IMAGE=$IMAGE_REPO:$TAG|" .env
+              case "$IMAGE_REPO" in
+                *.dkr.ecr.*.amazonaws.com/*)
+                  aws ecr get-login-password --region "${AWS_REGION:-eu-central-1}" \
+                    | docker login --username AWS --password-stdin "${IMAGE_REPO%%/*}" ;;
+              esac
               docker compose up -d --pull always zebra-testnet
               serve_genesis ;;
   restart)    docker compose restart zebra-testnet; serve_genesis ;;

--- a/testnet-single-node-deploy/ec2/ops.sh
+++ b/testnet-single-node-deploy/ec2/ops.sh
@@ -31,7 +31,7 @@ case "$ACTION" in
   stop)       docker compose stop zebra-testnet ;;
   logs)       docker compose logs zebra-testnet --tail=200 --no-color ;;
   status)     docker compose ps; bash /opt/zebra/leader.sh status ;;
-  promote)    bash /opt/zebra/leader.sh promote ;;
-  demote)     bash /opt/zebra/leader.sh demote ;;
+  # promote/demote are the workflow writing the Role tag; the box only matches it.
+  apply)      bash /opt/zebra/leader.sh apply ;;
   *) echo "unknown action: $ACTION"; exit 2 ;;
 esac

--- a/testnet-single-node-deploy/ec2/ops.sh
+++ b/testnet-single-node-deploy/ec2/ops.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# /opt/zebra/ops.sh <action> [tag] — invoked by the ops GitHub Action over SSM.
+set -euo pipefail
+cd /opt/zebra; source .env
+ACTION="${1:?usage: ops.sh <action> [tag]}"; TAG="${2:-latest}"
+
+# State is ephemeral and the node has no peers, so genesis is re-injected after
+# every start. Idempotent: an already-committed block returns "rejected", HTTP 200.
+serve_genesis() {
+  local hex
+  hex=$(docker exec zebra-testnet cat /app/zebra-test/src/vectors/block-test-0-000-000.txt | tr -d '[:space:]')
+  curl -s --retry 30 --retry-delay 2 --retry-connrefused --retry-all-errors \
+    http://127.0.0.1:18232 -X POST -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"1.0\",\"id\":\"ops\",\"method\":\"submitblock\",\"params\":[\"$hex\"]}"
+  echo
+}
+
+case "$ACTION" in
+  deploy)     sed -i "s|^IMAGE=.*|IMAGE=$IMAGE_REPO:$TAG|" .env
+              docker compose up -d --pull always zebra-testnet
+              serve_genesis ;;
+  restart)    docker compose restart zebra-testnet; serve_genesis ;;
+  start)      docker compose start zebra-testnet; serve_genesis ;;
+  recreate)   docker compose up -d --force-recreate zebra-testnet; serve_genesis ;;
+  genesis)    serve_genesis ;;
+  stop)       docker compose stop zebra-testnet ;;
+  logs)       docker compose logs zebra-testnet --tail=200 --no-color ;;
+  status)     docker compose ps; bash /opt/zebra/leader.sh status ;;
+  promote)    bash /opt/zebra/leader.sh promote ;;
+  demote)     bash /opt/zebra/leader.sh demote ;;
+  *) echo "unknown action: $ACTION"; exit 2 ;;
+esac

--- a/testnet-single-node-deploy/ec2/ops.sh
+++ b/testnet-single-node-deploy/ec2/ops.sh
@@ -6,7 +6,7 @@ ACTION="${1:?usage: ops.sh <action> [tag]}"; TAG="${2:-latest}"
 
 # State is ephemeral and the node has no peers, so genesis is re-injected after
 # every start. Idempotent: an already-committed block returns "rejected", HTTP 200.
-serve_genesis() {
+self_serve_genesis() {
   local hex
   hex=$(docker exec zebra-testnet cat /app/zebra-test/src/vectors/block-test-0-000-000.txt | tr -d '[:space:]')
   curl -s --retry 30 --retry-delay 2 --retry-connrefused --retry-all-errors \
@@ -23,11 +23,11 @@ case "$ACTION" in
                     | docker login --username AWS --password-stdin "${IMAGE_REPO%%/*}" ;;
               esac
               docker compose up -d --pull always zebra-testnet
-              serve_genesis ;;
-  restart)    docker compose restart zebra-testnet; serve_genesis ;;
-  start)      docker compose start zebra-testnet; serve_genesis ;;
-  recreate)   docker compose up -d --force-recreate zebra-testnet; serve_genesis ;;
-  genesis)    serve_genesis ;;
+              self_serve_genesis ;;
+  restart)    docker compose restart zebra-testnet; self_serve_genesis ;;
+  start)      docker compose start zebra-testnet; self_serve_genesis ;;
+  recreate)   docker compose up -d --force-recreate zebra-testnet; self_serve_genesis ;;
+  genesis)    self_serve_genesis ;;
   stop)       docker compose stop zebra-testnet ;;
   logs)       docker compose logs zebra-testnet --tail=200 --no-color ;;
   status)     docker compose ps; bash /opt/zebra/leader.sh status ;;

--- a/testnet-single-node-deploy/ec2/zebra-leader.service
+++ b/testnet-single-node-deploy/ec2/zebra-leader.service
@@ -1,0 +1,15 @@
+[Unit]
+# Re-runs the election on every boot, not just first boot. Without this a
+# stopped instance that lost the claim would come back and have docker's
+# restart policy start its cloudflared anyway.
+Description=Zebra tunnel leader election
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/bash /opt/zebra/leader.sh elect
+
+[Install]
+WantedBy=multi-user.target

--- a/testnet-single-node-deploy/ec2/zebra-leader.service
+++ b/testnet-single-node-deploy/ec2/zebra-leader.service
@@ -1,15 +1,14 @@
 [Unit]
-# Re-runs the election on every boot, not just first boot. Without this a
-# stopped instance that lost the claim would come back and have docker's
-# restart policy start its cloudflared anyway.
-Description=Zebra tunnel leader election
-After=docker.service
+Description=Match Zebra tunnel state to the Role tag
+# docker for compose, network-online for IMDS and the EC2 API.
 Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash /opt/zebra/leader.sh elect
+ExecStart=/bin/bash /opt/zebra/leader.sh apply
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Add EC2 runtime configuration and tunnel leader election for ZSATestnet

`testnet-configuration` of PR #149 defines the Zebra configuration needed to run ZSA as testnet instead of regtest, calling it the 'ZSATestnet' network and documents running it locally. This PR adds what's needed to run that same node on the shared EC2 box.

| File | |
| --- | --- |
| `docker-compose.yml` | zebrad + cloudflared + dozzle + logs-api |
| `leader.sh`, `zebra-leader.service` | tunnel leader election, runs every boot |
| `ops.sh` | lifecycle actions, invoked over SSM |
| `logs-api.py` | read-only JSON log endpoint |
| `README.md` | end-to-end instructions |

## Which config zebrad reads

The docker image is built from this repo with `COPY . .`, so
`testnet-config.toml` is already inside it at
`/app/testnet-single-node-deploy/testnet-config.toml`, and the compose
`entrypoint` points zebrad straight at that path.

Compose adds one env var, `ZEBRA_RPC__DEBUG_FORCE_FINISHED_SYNC=true`, affecting
only what `getblockchaininfo` reports. ZSATestnet sets `network = "Testnet"` (the
network *kind*), so zebrad estimates the tip from real Testnet and at height 1
claims ~4.1M blocks behind; the flag makes it report its own tip, so tooling that
checks sync state isn't misled. It does **not** gate `getblocktemplate` — that
needs an active mempool, already provided by `[mempool] debug_enable_at_height =
0`. Drop it if you'd rather stay byte-identical to a local run.

## Tunnel and leader election

`rpc.`/`logs.`/`dozzle.test-zsa.org` are served by `cloudflared`, using a single
tunnel token held in SSM. Cloudflare treats every `cloudflared` using that token
as another connector and load-balances across them, so only one instance may run
it — the leader.

`zebra-leader.service` → `leader.sh elect` decides that at every boot:

```
put-parameter /zebra/leader = <own-instance-id>   (no --overwrite)

  success                            -> tag Role=leader, start cloudflared
  ParameterAlreadyExists
    holder gone/terminated/stopped   -> overwrite, tag, start cloudflared
    holder running                   -> untag, stop own cloudflared
```

The write fails if the key exists, so simultaneous boots cannot both win. **The
first instance becomes leader; later ones come up without a connector and without
a `Role` tag**, serving no public traffic. Running it at every boot — not just the
first — stops docker's `restart: unless-stopped` from resurrecting a connector on
a box that lost the claim while stopped.

The launch template sets `DisableApiTermination`, so the leader can't be
terminated without disabling that first. If it is, there's no Auto Scaling group
to replace it: launch a new instance from the template and it claims leadership on
boot, because the recorded holder now resolves as terminated. To move the tunnel
between running instances instead, use `ops.sh promote`.

## Genesis

Zebra hard-codes a genesis block for Regtest only. ZSATestnet is a *configured*
testnet — own `network_name`, magic and activation heights under
`[network.testnet_parameters]` — and Zebra expects such a network to fetch genesis
from peers. `initial_testnet_peers` is empty, so nothing supplies it and the node
parks at `current_height=None`.

`ops.sh` submits it over RPC using curl from
`zebra-test/src/vectors/block-test-0-000-000.txt` inside the image, the same block
and approach as `CONFIGURED_TESTNET.md`. State is ephemeral, so this repeats on
`deploy`/`restart`/`start`/`recreate`; re-submitting is a no-op, returning
`"rejected"` over HTTP 200.

## Deployment

The launch template installs `leader.sh` and `zebra-leader.service` via `user_data`
and enables the unit, so a fresh instance elects on its own. The instance profile
it attaches grants the election `ssm:PutParameter`/`GetParameter`/`DeleteParameter`
on `/zebra/leader`, `ec2:CreateTags`/`DeleteTags` on itself restricted to the
`Role` key, and `ec2:DescribeInstances`. Both are already applied.

The ops workflow that targets `Role=leader` is in the separate PR #157 against
this branch.
