### PR TITLE
refactor(ec2): make tunnel leadership a tag the box follows

### DIFF
--- a/testnet-single-node-deploy/ec2/README.md
+++ b/testnet-single-node-deploy/ec2/README.md
@@ -23,53 +23,54 @@ All public and unauthenticated, and 18232/18233/8080 are open on the instance IP
 too. `enable_cookie_auth = false`, so anyone reaching 18232 can `stop` or
 `invalidateblock`. Disposable testnet only.
 
-## Instance tags and leader election
+## Leader election
 
 A Cloudflare Tunnel has one token, and every `cloudflared` holding it registers
 as another connector — Cloudflare then round-robins the public hostnames across
-them. So exactly one instance runs `cloudflared`: the one tagged `Role=leader`.
-**Only the leader carries that tag**; every other instance has no `Role` tag.
+them. That is meant for replicas. These nodes are not replicas: state is
+ephemeral, so each has its own chain, and two connectors means one hostname
+answering from two different chains. Hence exactly one instance may run
+`cloudflared`.
 
-`zebra-leader.service` runs `leader.sh elect` on **every** boot:
+**`Role=leader` marks that instance.** Only the leader carries the tag; every
+other instance has no `Role` tag.
+
+Nothing on the box elects, and nothing on the box writes the tag. `leader.sh
+apply` reads it and makes the box match:
 
 ```
-put-parameter /zebra/leader = <own-instance-id>   (no --overwrite)
-
-  success                            -> tag Role=leader, start cloudflared
-  ParameterAlreadyExists
-    holder gone/terminated/stopped   -> overwrite, tag, start cloudflared
-    holder running                   -> untag, stop own cloudflared
+Role=leader present -> ensure cloudflared up
+absent              -> ensure cloudflared down
 ```
 
-Without `--overwrite` the write fails if the key exists. That single atomic write
-is the whole election — two instances booting at once cannot both win.
+That runs at boot (`zebra-leader.service`) and on demand (`ops.sh apply`). There
+is no shared lock, no claim, and no state two boxes can disagree about — the tag
+is written in one place and every box is a follower of it.
 
-Nothing releases the parameter when a leader dies; termination runs no hook.
-Cleanup is lazy: the next instance to boot fails its claim, sees the holder is
-gone, and overwrites. Terminate everything, launch one, and the hostnames come
-back with no manual step.
+The ops workflow owns the verbs:
 
-Electing on every boot (not just first boot) is what makes taking over from a
-*stopped* holder safe. Compose uses `restart: unless-stopped`, so a box that lost
-the claim while stopped would otherwise have docker resurrect its connector,
-putting two on one tunnel — hence the losing branch stops cloudflared rather than
-just skipping it.
+| | |
+| --- | --- |
+| `promote B` | untag the current leader, tag B, `apply` to both |
+| `demote` | untag, `apply` |
+| leader terminated | nothing reclaims automatically — `promote` the replacement |
+| `up` fails | `apply` exits non-zero; run it again |
 
-`ops.sh promote` / `demote` move the tunnel without relaunching; `demote` also
-deletes the parameter so another node can claim it. `ops.sh status` prints
-`self=` and `leader=`.
+Two things keep a stale connector from coming back. `cloudflared` sits in the
+`tunnel` compose profile, so a bare `docker compose up -d` never starts one —
+only `leader.sh` does. And `restart: unless-stopped` revives the leader's
+connector after a reboot, which `apply` at boot undoes on a box that lost the tag
+while it was stopped.
 
-**`Name=zebra-testnet`** is how ops finds the box. The ops workflow with
-`instance_id` empty resolves `Name` + `Role=leader` + running and fails unless
-that is exactly one instance; set `instance_id` to target any other. Note the IAM
-role scopes `ssm:SendCommand` by `ssm:resourceTag/Name` against `instance/*`, so
-the `Name` tag is effectively a capability — tagging any instance in the account
-`zebra-testnet` grants the ops role shell on it.
+Instance profile needs only `ec2:DescribeTags` and `ssm:GetParameter`+
+`kms:Decrypt` on the tunnel token — no write permissions at all. Enabling
+instance metadata tags on the launch template would drop `ec2:DescribeTags` too,
+making `is_leader` a plain IMDS read.
 
-Election needs, on the instance profile: `ssm:PutParameter`/`GetParameter`/
-`DeleteParameter` on `/zebra/leader`, `ssm:GetParameter`+`kms:Decrypt` on the
-tunnel token, `ec2:CreateTags`+`ec2:DeleteTags` on itself scoped to the `Role`
-key, and `ec2:DescribeInstances`.
+**`Name=zebra-testnet`** is how ops finds the box. The IAM role scopes
+`ssm:SendCommand` by `ssm:resourceTag/Name` against `instance/*`, so that tag is
+effectively a capability — tagging any instance in the account `zebra-testnet`
+grants the ops role shell on it.
 
 ## Genesis
 
@@ -126,8 +127,8 @@ ZCASH_NODE_ADDRESS=rpc.test-zsa.org ZCASH_NODE_PORT=443 ZCASH_NODE_PROTOCOL=http
 ## ops.sh
 
 `deploy <tag>` · `restart` · `start` · `stop` · `recreate` · `genesis` · `logs` ·
-`status` · `promote` · `demote`. Everything that starts the node re-serves
-genesis.
+`status` · `apply`. Everything that starts the node re-serves genesis.
+`promote`/`demote` are workflow actions, not box actions — see above.
 
 ECR login expires after 12h and the box only logs in at first boot, so a manual
 `deploy` on an older box 401s — `docker login` first.

--- a/testnet-single-node-deploy/ec2/docker-compose.yml
+++ b/testnet-single-node-deploy/ec2/docker-compose.yml
@@ -19,10 +19,19 @@ services:
         max-size: "50m"
         max-file: "5"
 
+  # Started and stopped only by leader.sh. The profile keeps a bare
+  # `docker compose up -d` from starting a second connector by accident;
+  # `unless-stopped` brings the leader's back after a reboot, and leader.sh
+  # stops it at boot on a box that is no longer the leader.
   cloudflared:
+    profiles: [tunnel]
     image: cloudflare/cloudflared:latest
     restart: unless-stopped
-    command: tunnel run --token ${CF_TUNNEL_TOKEN}
+    # Token via env, not argv: on the command line it shows up in `docker
+    # inspect` and the host process list.
+    environment:
+      - TUNNEL_TOKEN=${CF_TUNNEL_TOKEN}
+    command: tunnel run
 
   dozzle:
     image: amir20/dozzle:latest

--- a/testnet-single-node-deploy/ec2/leader.sh
+++ b/testnet-single-node-deploy/ec2/leader.sh
@@ -1,64 +1,60 @@
 #!/usr/bin/env bash
-# /opt/zebra/leader.sh <elect|promote|demote|status>
+# /opt/zebra/leader.sh [apply|status]
 #
-# The leader is the one instance tagged Role=leader, and the only one running cloudflared.
+# Only one instance may run cloudflared. Every process holding the tunnel token
+# registers as another connector and Cloudflare load-balances across them, but
+# these nodes are not replicas — each has its own ephemeral chain, so two
+# connectors means one hostname answering from two different chains.
 #
-# Claim is an SSM put-parameter WITHOUT --overwrite, which fails if the key
-# exists. That is the atomic bit: simultaneous boots cannot both win.
+# Role=leader marks the instance allowed to run it. The ops workflow writes that
+# tag; this script only makes the box match it. Nothing here elects and nothing
+# here writes the tag, so there is no shared state to race over.
 set -euo pipefail
-PARAM=/zebra/leader
+cd /opt/zebra
 REGION="${AWS_REGION:-eu-central-1}"
+TOKEN_PARAM=/zebra/zebra-testnet/cf-tunnel-token
+IMDS=http://169.254.169.254/latest
 
-TOKEN=$(curl -sX PUT http://169.254.169.254/latest/api/token \
+T=$(curl -sf --retry 5 --retry-delay 1 -X PUT "$IMDS/api/token" \
   -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
-ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
-  http://169.254.169.254/latest/meta-data/instance-id)
+ID=$(curl -sf --retry 5 --retry-delay 1 -H "X-aws-ec2-metadata-token: $T" \
+  "$IMDS/meta-data/instance-id")
+[[ $ID == i-* ]] || { echo "bad instance id: '$ID'" >&2; exit 1; }
 
-put() { aws ssm put-parameter --region "$REGION" --name "$PARAM" \
-  --type String --value "$ID" "$@" >/dev/null; }
-get() { aws ssm get-parameter --region "$REGION" --name "$PARAM" \
-  --query Parameter.Value --output text 2>/dev/null || true; }
-# Role=leader exists only on the leader. Followers carry no Role tag at all.
-tag()   { aws ec2 create-tags --region "$REGION" --resources "$ID" --tags Key=Role,Value=leader; }
-untag() { aws ec2 delete-tags --region "$REGION" --resources "$ID" --tags Key=Role; }
+# cloudflared sits in a compose profile, so a bare `docker compose up -d` cannot
+# start a connector by accident. Always address it through the profile.
+dc() { docker compose --profile tunnel "$@"; }
+running() { [ -n "$(dc ps -q cloudflared)" ]; }
+# Prints the Role tag, or "None". Non-zero means we could not find out, which is
+# not the same as "not the leader" — see the hard exit below.
+role() { aws ec2 describe-tags --region "$REGION" \
+  --filters "Name=resource-id,Values=$ID" "Name=key,Values=Role" \
+  --query 'Tags[0].Value' --output text; }
 
-# 0 if we hold the claim afterwards. Takes over from any holder that is not
-# actually serving: gone, terminated, or stopped. Safe because elect runs on
-# every boot (zebra-leader.service), so a stopped holder that comes back finds
-# it has lost and shuts its own cloudflared down.
-claim() {
-  put 2>/dev/null && return 0
-  local cur state
-  cur=$(get)
-  [ "$cur" = "$ID" ] && return 0
-  state=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$cur" \
-    --query 'Reservations[].Instances[].State.Name' --output text 2>/dev/null || echo gone)
-  case "$state" in
-    ""|None|gone|terminated|shutting-down|stopped|stopping) put --overwrite; return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-start_tunnel() {
+up() {
+  if running; then return 0; fi
   local t
-  t=$(aws ssm get-parameter --region "$REGION" --name /zebra/zebra-testnet/cf-tunnel-token \
+  t=$(aws ssm get-parameter --region "$REGION" --name "$TOKEN_PARAM" \
     --with-decryption --query Parameter.Value --output text)
-  sed -i "s|^CF_TUNNEL_TOKEN=.*|CF_TUNNEL_TOKEN=$t|" /opt/zebra/.env
-  cd /opt/zebra && docker compose up -d cloudflared
+  grep -q '^CF_TUNNEL_TOKEN=' .env || { echo "no CF_TUNNEL_TOKEN= line in .env" >&2; return 1; }
+  sed -i "s|^CF_TUNNEL_TOKEN=.*|CF_TUNNEL_TOKEN=$t|" .env
+  dc up -d cloudflared
 }
 
-case "${1:-elect}" in
-  # Runs at every boot. Losing means stopping our own cloudflared: docker's
-  # restart policy would otherwise resurrect it on a box that lost the claim
-  # while it was stopped, putting two connectors on the tunnel.
-  elect)   if claim; then tag; start_tunnel; echo leader
-           else untag 2>/dev/null || true
-                cd /opt/zebra && docker compose stop cloudflared >/dev/null 2>&1 || true
-                echo follower; fi ;;
-  promote) put --overwrite; tag; start_tunnel; echo "leader: $ID" ;;
-  # Releases the claim too, so the next elect can take over while this box lives.
-  demote)  untag; aws ssm delete-parameter --region "$REGION" --name "$PARAM" 2>/dev/null || true
-           cd /opt/zebra && docker compose stop cloudflared; echo "released: $ID" ;;
-  status)  echo "self=$ID leader=$(get)" ;;
-  *) echo "usage: leader.sh <elect|promote|demote|status>"; exit 2 ;;
-esac
+ACTION="${1:-apply}"
+case $ACTION in apply|status) ;; *) echo "usage: leader.sh [apply|status]" >&2; exit 2 ;; esac
+
+# Fail closed. A throttled or denied lookup must not read as "not the leader",
+# which would take the tunnel down over a transient API error.
+R=$(role) || { echo "Role tag lookup failed; leaving cloudflared as-is" >&2; exit 1; }
+
+# apply runs at boot and on demand. At boot it also undoes docker's restart
+# policy reviving a connector on a box that lost the tag while it was stopped.
+if [ "$ACTION" = status ]; then
+  echo "self=$ID leader=$([ "$R" = leader ] && echo yes || echo no)" \
+       "cloudflared=$(running && echo up || echo down)"
+elif [ "$R" = leader ]; then
+  up
+else
+  dc stop cloudflared >/dev/null
+fi

--- a/testnet-single-node-deploy/ec2/ops.sh
+++ b/testnet-single-node-deploy/ec2/ops.sh
@@ -26,7 +26,7 @@ case "$ACTION" in
   stop)       docker compose stop zebra-testnet ;;
   logs)       docker compose logs zebra-testnet --tail=200 --no-color ;;
   status)     docker compose ps; bash /opt/zebra/leader.sh status ;;
-  promote)    bash /opt/zebra/leader.sh promote ;;
-  demote)     bash /opt/zebra/leader.sh demote ;;
+  # promote/demote are the workflow writing the Role tag; the box only matches it.
+  apply)      bash /opt/zebra/leader.sh apply ;;
   *) echo "unknown action: $ACTION"; exit 2 ;;
 esac

--- a/testnet-single-node-deploy/ec2/zebra-leader.service
+++ b/testnet-single-node-deploy/ec2/zebra-leader.service
@@ -1,15 +1,14 @@
 [Unit]
-# Re-runs the election on every boot, not just first boot. Without this a
-# stopped instance that lost the claim would come back and have docker's
-# restart policy start its cloudflared anyway.
-Description=Zebra tunnel leader election
-After=docker.service
+Description=Match Zebra tunnel state to the Role tag
+# docker for compose, network-online for IMDS and the EC2 API.
 Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash /opt/zebra/leader.sh elect
+ExecStart=/bin/bash /opt/zebra/leader.sh apply
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Make tunnel leadership a tag the box follows

On top of #158.

Only one instance may run `cloudflared`: every process holding the tunnel token registers as
another connector and Cloudflare load-balances across them, but these nodes are not replicas —
each has its own ephemeral chain, so two connectors means one hostname answering from two
different chains.

`Role=leader` is written in one place — the ops workflow — and `leader.sh apply` reads it and
makes the box match: connector up if tagged, down if not, and on a failed lookup it exits
non-zero and changes nothing rather than reading "not the leader". It runs at boot and on demand
(`ops.sh apply`). No claim, no lock, no state two boxes can disagree about, so the races are gone
rather than fixed. The instance profile drops to `ec2:DescribeTags` plus the token read — no
write permission at all.

`promote`/`demote` stay operator verbs but move to the workflow. `ops.sh` loses them, gains
`apply`. `leader.sh` goes from 64 lines to 60 and from four verbs to one.

Two things keep a stale connector from returning: `cloudflared` moves into a `tunnel` compose
profile so a bare `docker compose up -d` can't start one, and `restart: unless-stopped` revives
the leader's after a reboot — which `apply` at boot undoes on a box that lost the tag while
stopped.

The tunnel token also moves from argv to `TUNNEL_TOKEN`, where it no longer shows up in `docker inspect` and the host process list.

### Needed in #157

The box no longer has `promote`/`demote`, so the workflow has to implement them:

1. **`promote` requires an explicit `instance_id`** — its target is the *new* leader, so the
   resolve-the-current-leader path doesn't apply.
2. **Handle both actions on the runner**, before the generic SSM step: find the current leader by tag, remove its `Role` tag, tag the target for `promote`, then send `ops.sh apply` to both boxes so each matches its new tag.
3. **Refuse to promote past an incumbent in state `stopped`.** SSM can't reach it to stand it
   down, and docker's restart policy revives its connector on next start. A *terminated*
   incumbent is always safe — it never comes back.
4. **Skip the generic `ops.sh <action>` step** for `promote`/`demote`.
5. **Grant the ops role `ec2:CreateTags`/`ec2:DeleteTags`** on `zebra-testnet` instances scoped to the `Role` key — the permission the instance profile is giving up.



